### PR TITLE
Minor netcode oversights

### DIFF
--- a/src/netcode/d_net.c
+++ b/src/netcode/d_net.c
@@ -164,6 +164,12 @@ typedef struct
 	// ack return to send (like sliding window protocol)
 	UINT8 firstacktosend;
 
+	// when no consecutive packets are received we keep in mind what packets
+	// we already received in a queue
+	UINT8 acktosend_head;
+	UINT8 acktosend_tail;
+	UINT8 acktosend[MAXACKTOSEND];
+
 	// automatically send keep alive packet when not enough trafic
 	tic_t lasttimeacktosend_sent;
 	// detect connection lost
@@ -282,7 +288,15 @@ static boolean Processackpak(void)
 		getackpacket++;
 		if (cmpack(ack, node->firstacktosend) <= 0)
 		{
+			UINT8 newhead = (UINT8)((node->acktosend_head+1) % MAXACKTOSEND);
 			DEBFILE(va("Discard(1) ack %d (duplicated)\n", ack));
+			if (newhead != node->acktosend_tail)
+			{
+				// push the ack back onto the acktosend list to make sure it's responded to
+				node->acktosend[node->acktosend_head] = ack;
+				node->acktosend_head = newhead;
+			}
+
 			duppacket++;
 			goodpacket = false; // Discard packet (duplicate)
 		}
@@ -387,44 +401,6 @@ void Net_UnAcknowledgePacket(INT32 node)
 	nodes[node].firstacktosend--;
 	if (!nodes[node].firstacktosend)
 		nodes[node].firstacktosend = UINT8_MAX;
-}
-
-/** Checks if all acks have been received
-  *
-  * \return True if all acks have been received
-  *
-  */
-static boolean Net_AllAcksReceived(void)
-{
-	for (INT32 i = 0; i < MAXACKPACKETS; i++)
-		if (ackpak[i].acknum)
-			return false;
-
-	return true;
-}
-
-/** Waits for all ackreturns
-  *
-  * \param timeout Timeout in seconds
-  *
-  */
-void Net_WaitAllAckReceived(UINT32 timeout)
-{
-	tic_t tictac = I_GetTime();
-	timeout = tictac + timeout*NEWTICRATE;
-
-	HGetPacket();
-	while (timeout > I_GetTime() && !Net_AllAcksReceived())
-	{
-		while (tictac == I_GetTime())
-		{
-			I_Sleep(cv_sleep.value);
-			I_UpdateTime(cv_timescale.value);
-		}
-		tictac = I_GetTime();
-		HGetPacket();
-		Net_AckTicker();
-	}
 }
 
 static void InitNode(node_t *node)
@@ -1175,9 +1151,6 @@ void D_CloseConnection(void)
 {
 	if (netgame)
 	{
-		// wait the ackreturn with timout of 5 Sec
-		Net_WaitAllAckReceived(5);
-
 		// close all connection
 		for (INT32 i = 0; i < MAXNETNODES; i++)
 			Net_CloseConnection(i|FORCECLOSE);

--- a/src/netcode/d_netcmd.c
+++ b/src/netcode/d_netcmd.c
@@ -225,7 +225,7 @@ static consvar_t cv_fishcake = CVAR_INIT ("fishcake", "Off", CV_CALL|CV_NOSHOWHE
 #endif
 static consvar_t cv_dummyconsvar = CVAR_INIT ("dummyconsvar", "Off", CV_CALL|CV_NOSHOWHELP, CV_OnOff, DummyConsvar_OnChange);
 
-consvar_t cv_restrictmoveskinchange = CVAR_INIT ("restrictmoveskinchange", "Yes", CV_SAVE|CV_NETVAR|CV_CHEAT|CV_ALLOWLUA, CV_YesNo, NULL);
+consvar_t cv_restrictmoveskinchange = CVAR_INIT ("restrictmoveskinchange", "Yes", CV_SAVE|CV_CHEAT|CV_ALLOWLUA, CV_YesNo, NULL);
 consvar_t cv_restrictskinchange = CVAR_INIT ("restrictskinchange", "Yes", CV_SAVE|CV_NETVAR|CV_CHEAT|CV_ALLOWLUA, CV_YesNo, NULL);
 consvar_t cv_allowteamchange = CVAR_INIT ("allowteamchange", "Yes", CV_SAVE|CV_NETVAR|CV_ALLOWLUA, CV_YesNo, NULL);
 


### PR DESCRIPTION
Restores NetXCmd queuing and disconnection fix, and removes CV_NETVAR from cv_restrictmoveskinchange.