### PR TITLE
Fix local angle camera bug on respawn

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -11785,7 +11785,6 @@ void P_AfterPlayerSpawn(INT32 playernum)
 	mobj_t *mobj = p->mo;
 
 	P_SetPlayerAngle(p, mobj->angle);
-	P_ForceLocalAngle(p, mobj->angle);
 
 	p->viewheight = 41*p->height/48;
 


### PR DESCRIPTION
Fixes a regression made by #4 where on netgames (or mindelay) if you respawn whole moving the camera on death, the camera angle gets permanently shifted until map change or respawning without moving the camera.