### PR TITLE
Various camera features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ You can compile the source code normally (see "Compiling") and put the binary in
 
 ## Visual
 - Toggable mobj pitch/roll functional (3d rotation for models on slopes, like DRRR). Option located in Video Settings -> Level -> "Pitch/Roll Rotation"
+- New camera options!
+  - "`cam_clipping`": 0 = noclip, 1 = vanilla, 2 = Roblox-style clip
+  - "`cam_exact`": off = vanilla, on = precise camera movement
+  - Combine `cam_clipping 2`, `cam_exact on`, and `cam_speed 1` for a Roblox-like camera!
 - Ring-Racers-styled screen quakes! ("`rr_quakes`" in console)
 - Toggleable Screenshake effects! ("`earthquake`", ported from SRB2Classic by @archiNiko)
 - Better "Fake Contrast"! (https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2680, @GLideKS)

--- a/src/lua_baselib.c
+++ b/src/lua_baselib.c
@@ -2239,7 +2239,7 @@ static int lib_pTryCameraMove(lua_State *L)
 
 	if (!cam)
 		return LUA_ErrInvalid(L, "camera_t");
-	lua_pushboolean(L, P_TryCameraMove(x, y, cam, false));
+	lua_pushboolean(L, P_TryCameraMove(x, y, cam));
 	return 1;
 }
 

--- a/src/lua_baselib.c
+++ b/src/lua_baselib.c
@@ -2239,7 +2239,7 @@ static int lib_pTryCameraMove(lua_State *L)
 
 	if (!cam)
 		return LUA_ErrInvalid(L, "camera_t");
-	lua_pushboolean(L, P_TryCameraMove(x, y, cam));
+	lua_pushboolean(L, P_TryCameraMove(x, y, cam, false));
 	return 1;
 }
 

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -131,7 +131,7 @@ INT32 P_GetPlayerControlDirection(player_t *player);
 void P_AddPlayerScore(player_t *player, UINT32 amount);
 void P_StealPlayerScore(player_t *player, UINT32 amount);
 void P_ResetCamera(player_t *player, camera_t *thiscam);
-boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam, boolean exact);
+boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam);
 void P_SlideCameraMove(camera_t *thiscam);
 boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcalled);
 pflags_t P_GetJumpFlags(player_t *player);
@@ -426,7 +426,7 @@ void P_SetThingPosition(mobj_t *thing);
 void P_SetUnderlayPosition(mobj_t *thing);
 
 boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y);
-boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam, boolean exact); // romoney5: why is this defined twice?
+boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam); // romoney5: why is this defined twice?
 boolean P_IsCameraNoclip(camera_t *thiscam);
 boolean P_CheckCameraPosition(fixed_t x, fixed_t y, camera_t *thiscam);
 boolean P_CheckMove(mobj_t *thing, fixed_t x, fixed_t y, boolean allowdropoff);

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -118,6 +118,7 @@ extern consvar_t cv_cam2_speed, cv_cam2_rotate, cv_cam2_rotspeed, cv_cam2_turnmu
 extern consvar_t cv_earthquake;
 
 extern consvar_t cv_cam_noclip, cv_cam2_noclip;
+extern consvar_t cv_cam_exact, cv_cam2_exact;
 
 extern consvar_t cv_cam_savedist[2][2], cv_cam_saveheight[2][2];
 void CV_UpdateCamDist(void);

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -117,6 +117,8 @@ extern consvar_t cv_cam2_speed, cv_cam2_rotate, cv_cam2_rotspeed, cv_cam2_turnmu
 
 extern consvar_t cv_earthquake;
 
+extern consvar_t cv_cam_noclip, cv_cam2_noclip;
+
 extern consvar_t cv_cam_savedist[2][2], cv_cam_saveheight[2][2];
 void CV_UpdateCamDist(void);
 void CV_UpdateCam2Dist(void);
@@ -423,6 +425,8 @@ void P_SetThingPosition(mobj_t *thing);
 void P_SetUnderlayPosition(mobj_t *thing);
 
 boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y);
+boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam);
+boolean P_IsCameraNoclip(camera_t *thiscam);
 boolean P_CheckCameraPosition(fixed_t x, fixed_t y, camera_t *thiscam);
 boolean P_CheckMove(mobj_t *thing, fixed_t x, fixed_t y, boolean allowdropoff);
 boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, boolean allowdropoff);

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -117,7 +117,7 @@ extern consvar_t cv_cam2_speed, cv_cam2_rotate, cv_cam2_rotspeed, cv_cam2_turnmu
 
 extern consvar_t cv_earthquake;
 
-extern consvar_t cv_cam_noclip, cv_cam2_noclip;
+extern consvar_t cv_cam_clipping, cv_cam2_clipping;
 extern consvar_t cv_cam_exact, cv_cam2_exact;
 
 extern consvar_t cv_cam_savedist[2][2], cv_cam_saveheight[2][2];
@@ -131,7 +131,7 @@ INT32 P_GetPlayerControlDirection(player_t *player);
 void P_AddPlayerScore(player_t *player, UINT32 amount);
 void P_StealPlayerScore(player_t *player, UINT32 amount);
 void P_ResetCamera(player_t *player, camera_t *thiscam);
-boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam);
+boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam, boolean exact);
 void P_SlideCameraMove(camera_t *thiscam);
 boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcalled);
 pflags_t P_GetJumpFlags(player_t *player);
@@ -426,7 +426,7 @@ void P_SetThingPosition(mobj_t *thing);
 void P_SetUnderlayPosition(mobj_t *thing);
 
 boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y);
-boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam);
+boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam, boolean exact); // romoney5: why is this defined twice?
 boolean P_IsCameraNoclip(camera_t *thiscam);
 boolean P_CheckCameraPosition(fixed_t x, fixed_t y, camera_t *thiscam);
 boolean P_CheckMove(mobj_t *thing, fixed_t x, fixed_t y, boolean allowdropoff);

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2338,10 +2338,6 @@ boolean P_CheckCameraPosition(fixed_t x, fixed_t y, camera_t *thiscam)
 	INT32 xl, xh, yl, yh, bx, by;
 	subsector_t *newsubsec;
 
-	// romoney5: noclip camera
-	if (P_IsCameraNoclip(thiscam))
-		return true;
-
 	tmx = x;
 	tmy = y;
 
@@ -2513,7 +2509,7 @@ boolean P_CheckCameraPosition(fixed_t x, fixed_t y, camera_t *thiscam)
 //
 // Return true if the move succeeded and no sliding should be done.
 //
-boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam, boolean exact)
+boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam)
 {
 	subsector_t *s = R_PointInSubsector(x, y);
 	boolean itsatwodlevel = false;
@@ -2528,7 +2524,7 @@ boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam, boolean exact)
 		|| (thiscam == &camera2 && players[secondarydisplayplayer].mo && (players[secondarydisplayplayer].mo->flags2 & MF2_TWOD)))
 		itsatwodlevel = true;
 
-	if (!itsatwodlevel && players[displayplayer].mo && (!P_IsCameraNoclip(thiscam) || exact))
+	if (!itsatwodlevel && players[displayplayer].mo && !P_IsCameraNoclip(thiscam))
 	{
 		fixed_t tryx = thiscam->x;
 		fixed_t tryy = thiscam->y;
@@ -3625,11 +3621,11 @@ retry:
 	// move up to the wall
 	if (bestslidefrac == FRACUNIT+1)
 	{
-		retval = P_TryCameraMove(thiscam->x, thiscam->y + thiscam->momy, thiscam, false);
+		retval = P_TryCameraMove(thiscam->x, thiscam->y + thiscam->momy, thiscam);
 		// the move must have hit the middle, so stairstep
 stairstep:
 		if (!retval) // Allow things to drop off.
-			P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y, thiscam, false);
+			P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y, thiscam);
 		return;
 	}
 
@@ -3640,7 +3636,7 @@ stairstep:
 		newx = FixedMul(thiscam->momx, bestslidefrac);
 		newy = FixedMul(thiscam->momy, bestslidefrac);
 
-		retval = P_TryCameraMove(thiscam->x + newx, thiscam->y + newy, thiscam, false);
+		retval = P_TryCameraMove(thiscam->x + newx, thiscam->y + newy, thiscam);
 
 		if (!retval)
 			goto stairstep;
@@ -3664,7 +3660,7 @@ stairstep:
 	thiscam->momx = tmxmove;
 	thiscam->momy = tmymove;
 
-	retval = P_TryCameraMove(thiscam->x + tmxmove, thiscam->y + tmymove, thiscam, false);
+	retval = P_TryCameraMove(thiscam->x + tmxmove, thiscam->y + tmymove, thiscam);
 
 	if (!retval)
 		goto retry;

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2313,6 +2313,23 @@ void P_CheckHoopPosition(mobj_t *hoopthing, fixed_t x, fixed_t y, fixed_t z, fix
 	return;
 }
 
+// romoney5: noclip camera
+boolean P_IsCameraNoclip(camera_t *thiscam)
+{
+	if (thiscam == &camera)
+	{
+		if (cv_cam_noclip.value)
+			return true;
+	}
+	else // Camera 2
+	{
+		if (cv_cam2_noclip.value)
+			return true;
+	}
+
+	return false;
+}
+
 //
 // P_CheckCameraPosition
 //
@@ -2320,6 +2337,10 @@ boolean P_CheckCameraPosition(fixed_t x, fixed_t y, camera_t *thiscam)
 {
 	INT32 xl, xh, yl, yh, bx, by;
 	subsector_t *newsubsec;
+
+	// romoney5: noclip camera
+	if (P_IsCameraNoclip(thiscam))
+		return true;
 
 	tmx = x;
 	tmy = y;
@@ -2507,7 +2528,7 @@ boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam)
 		|| (thiscam == &camera2 && players[secondarydisplayplayer].mo && (players[secondarydisplayplayer].mo->flags2 & MF2_TWOD)))
 		itsatwodlevel = true;
 
-	if (!itsatwodlevel && players[displayplayer].mo)
+	if (!itsatwodlevel && players[displayplayer].mo && !P_IsCameraNoclip(thiscam))
 	{
 		fixed_t tryx = thiscam->x;
 		fixed_t tryy = thiscam->y;

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2318,12 +2318,12 @@ boolean P_IsCameraNoclip(camera_t *thiscam)
 {
 	if (thiscam == &camera)
 	{
-		if (cv_cam_noclip.value)
+		if (cv_cam_clipping.value != 1)
 			return true;
 	}
 	else // Camera 2
 	{
-		if (cv_cam2_noclip.value)
+		if (cv_cam2_clipping.value != 1)
 			return true;
 	}
 
@@ -2513,7 +2513,7 @@ boolean P_CheckCameraPosition(fixed_t x, fixed_t y, camera_t *thiscam)
 //
 // Return true if the move succeeded and no sliding should be done.
 //
-boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam)
+boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam, boolean exact)
 {
 	subsector_t *s = R_PointInSubsector(x, y);
 	boolean itsatwodlevel = false;
@@ -2528,7 +2528,7 @@ boolean P_TryCameraMove(fixed_t x, fixed_t y, camera_t *thiscam)
 		|| (thiscam == &camera2 && players[secondarydisplayplayer].mo && (players[secondarydisplayplayer].mo->flags2 & MF2_TWOD)))
 		itsatwodlevel = true;
 
-	if (!itsatwodlevel && players[displayplayer].mo && !P_IsCameraNoclip(thiscam))
+	if (!itsatwodlevel && players[displayplayer].mo && (!P_IsCameraNoclip(thiscam) || exact))
 	{
 		fixed_t tryx = thiscam->x;
 		fixed_t tryy = thiscam->y;
@@ -3625,11 +3625,11 @@ retry:
 	// move up to the wall
 	if (bestslidefrac == FRACUNIT+1)
 	{
-		retval = P_TryCameraMove(thiscam->x, thiscam->y + thiscam->momy, thiscam);
+		retval = P_TryCameraMove(thiscam->x, thiscam->y + thiscam->momy, thiscam, false);
 		// the move must have hit the middle, so stairstep
 stairstep:
 		if (!retval) // Allow things to drop off.
-			P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y, thiscam);
+			P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y, thiscam, false);
 		return;
 	}
 
@@ -3640,7 +3640,7 @@ stairstep:
 		newx = FixedMul(thiscam->momx, bestslidefrac);
 		newy = FixedMul(thiscam->momy, bestslidefrac);
 
-		retval = P_TryCameraMove(thiscam->x + newx, thiscam->y + newy, thiscam);
+		retval = P_TryCameraMove(thiscam->x + newx, thiscam->y + newy, thiscam, false);
 
 		if (!retval)
 			goto stairstep;
@@ -3664,7 +3664,7 @@ stairstep:
 	thiscam->momx = tmxmove;
 	thiscam->momy = tmymove;
 
-	retval = P_TryCameraMove(thiscam->x + tmxmove, thiscam->y + tmymove, thiscam);
+	retval = P_TryCameraMove(thiscam->x + tmxmove, thiscam->y + tmymove, thiscam, false);
 
 	if (!retval)
 		goto retry;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -3579,7 +3579,7 @@ boolean P_CameraThinker(player_t *player, camera_t *thiscam, boolean resetcalled
 		// adjust height
 		thiscam->z += thiscam->momz + player->mo->pmomz;
 
-		if (!itsatwodlevel && !(player->pflags & PF_NOCLIP || player->powers[pw_carry] == CR_NIGHTSMODE))
+		if (!itsatwodlevel && !(player->pflags & PF_NOCLIP || player->powers[pw_carry] == CR_NIGHTSMODE) && !P_IsCameraNoclip(thiscam))
 		{
 			// clip movement
 			if (thiscam->z <= thiscam->floorz) // hit the floor

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -3539,7 +3539,7 @@ boolean P_CameraThinker(player_t *player, camera_t *thiscam, boolean resetcalled
 
 	if (thiscam->momx || thiscam->momy)
 	{
-		if (!P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y + thiscam->momy, thiscam, false)) // Thanks for the greatly improved camera, Lach -- Sev
+		if (!P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y + thiscam->momy, thiscam)) // Thanks for the greatly improved camera, Lach -- Sev
 		{ // Never fails for 2D mode.
 			mobj_t dummy;
 			dummy.thinker.function = (actionf_p1)P_MobjThinker;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -3539,7 +3539,7 @@ boolean P_CameraThinker(player_t *player, camera_t *thiscam, boolean resetcalled
 
 	if (thiscam->momx || thiscam->momy)
 	{
-		if (!P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y + thiscam->momy, thiscam)) // Thanks for the greatly improved camera, Lach -- Sev
+		if (!P_TryCameraMove(thiscam->x + thiscam->momx, thiscam->y + thiscam->momy, thiscam, false)) // Thanks for the greatly improved camera, Lach -- Sev
 		{ // Never fails for 2D mode.
 			mobj_t dummy;
 			dummy.thinker.function = (actionf_p1)P_MobjThinker;

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9854,6 +9854,10 @@ consvar_t cv_earthquake = CVAR_INIT("earthquake", "On", CV_SAVE|CV_CLIENT, CV_On
 consvar_t cv_cam_noclip = CVAR_INIT ("cam_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_cam2_noclip = CVAR_INIT ("cam2_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 
+// romoney5: exact camera aiming
+consvar_t cv_cam_exact = CVAR_INIT ("cam_exact", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
+consvar_t cv_cam2_exact = CVAR_INIT ("cam2_exact", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
+
 
 // [standard vs simple][p1 or p2]
 consvar_t cv_cam_savedist[2][2] = {
@@ -9955,7 +9959,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 	angle_t angle = 0, focusangle = 0, focusaiming = 0;
 	fixed_t x, y, z, dist, distxy, distz, checkdist, viewpointx, viewpointy, camspeed, camdist, camheight, pviewheight, slopez = 0;
 	INT32 camrotate;
-	boolean camstill, cameranoclip, camorbit;
+	boolean camstill, cameranoclip, camorbit, cameraexact;
 	mobj_t *mo, *sign = NULL;
 	subsector_t *newsubsec;
 	fixed_t f1, f2;
@@ -10084,9 +10088,6 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		focusaiming = player->aiming;
 	}
 
-	if (P_CameraThinker(player, thiscam, resetcalled))
-		return true;
-
 	if (thiscam == &camera)
 	{
 		camspeed = cv_cam_speed.value;
@@ -10095,6 +10096,8 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		camrotate = cv_cam_rotate.value;
 		camdist = FixedMul(cv_cam_dist.value, mo->scale);
 		camheight = FixedMul(cv_cam_height.value, mo->scale);
+
+		cameraexact = cv_cam_exact.value;
 	}
 	else // Camera 2
 	{
@@ -10104,7 +10107,12 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		camrotate = cv_cam2_rotate.value;
 		camdist = FixedMul(cv_cam2_dist.value, mo->scale);
 		camheight = FixedMul(cv_cam2_height.value, mo->scale);
+
+		cameraexact = cv_cam2_exact.value;
 	}
+
+	if (!cameraexact && P_CameraThinker(player, thiscam, resetcalled))
+		return true;
 
 	if (!(twodlevel || (mo->flags2 & MF2_TWOD)) && !(player->powers[pw_carry] == CR_NIGHTSMODE))
 		camheight = FixedMul(camheight, player->camerascale);
@@ -10557,7 +10565,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		viewpointy = mo->y + shifty + FixedMul(FINESINE((angle>>ANGLETOFINESHIFT) & FINEMASK), dist);
 	}
 
-	if (!camstill && !resetcalled && !paused)
+	if (!camstill && !resetcalled && !paused && !cameraexact)
 		thiscam->angle = R_PointToAngle2(thiscam->x, thiscam->y, viewpointx, viewpointy);
 
 /*
@@ -10575,6 +10583,42 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 			return true;
 		}
 	}*/
+
+	// compute aming to look the viewed point
+	f1 = viewpointx-thiscam->x;
+	f2 = viewpointy-thiscam->y;
+	dist = FixedHypot(f1, f2);
+
+	if (mo->eflags & MFE_VERTICALFLIP)
+		angle = R_PointToAngle2(0, thiscam->z + thiscam->height, dist, (sign ? sign->ceilingz : mo->z + mo->height) - P_GetPlayerHeight(player));
+	else
+		angle = R_PointToAngle2(0, thiscam->z, dist, (sign ? sign->floorz : mo->z) + P_GetPlayerHeight(player));
+	if (player->playerstate != PST_DEAD)
+		angle += (focusaiming < ANGLE_180 ? focusaiming/2 : InvAngle(InvAngle(focusaiming)/2)); // overcomplicated version of '((signed)focusaiming)/2;'
+
+	if (twodlevel || (mo->flags2 & MF2_TWOD) || !camstill) // Keep the view still...
+	{
+
+		if (cameraexact)
+		{
+			angle = focusaiming;
+			if (mo->eflags & MFE_VERTICALFLIP)
+				z = z + camheight / 2;
+			else
+				z = z - camheight / 2;
+
+			G_ClipAimingPitch((INT32 *)&angle);
+			dist = thiscam->aiming - angle;
+			thiscam->aiming -= FixedMul(dist, camspeed);
+		}
+		else
+		{
+			G_ClipAimingPitch((INT32 *)&angle);
+			dist = thiscam->aiming - angle;
+			thiscam->aiming -= (dist>>3);
+		}
+	}
+
 
 	if (twodlevel || (mo->flags2 & MF2_TWOD))
 	{
@@ -10598,25 +10642,6 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 
 		thiscam->momx += FixedMul(shiftx, camspeed);
 		thiscam->momy += FixedMul(shifty, camspeed);
-	}
-
-	// compute aming to look the viewed point
-	f1 = viewpointx-thiscam->x;
-	f2 = viewpointy-thiscam->y;
-	dist = FixedHypot(f1, f2);
-
-	if (mo->eflags & MFE_VERTICALFLIP)
-		angle = R_PointToAngle2(0, thiscam->z + thiscam->height, dist, (sign ? sign->ceilingz : mo->z + mo->height) - P_GetPlayerHeight(player));
-	else
-		angle = R_PointToAngle2(0, thiscam->z, dist, (sign ? sign->floorz : mo->z) + P_GetPlayerHeight(player));
-	if (player->playerstate != PST_DEAD)
-		angle += (focusaiming < ANGLE_180 ? focusaiming/2 : InvAngle(InvAngle(focusaiming)/2)); // overcomplicated version of '((signed)focusaiming)/2;'
-
-	if (twodlevel || (mo->flags2 & MF2_TWOD) || !camstill) // Keep the view still...
-	{
-		G_ClipAimingPitch((INT32 *)&angle);
-		dist = thiscam->aiming - angle;
-		thiscam->aiming -= (dist>>3);
 	}
 
 	// Make player translucent if camera is too close (only in single player).
@@ -10663,6 +10688,13 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		else if (mo->eflags & MFE_VERTICALFLIP && thiscam->aiming > ANGLE_22h && thiscam->aiming < ANGLE_180)
 			thiscam->aiming = ANGLE_22h;
 	}
+
+	// romoney5: move after setting momentum
+	if (cameraexact && P_CameraThinker(player, thiscam, resetcalled))
+		return true;
+
+	if (!camstill && !resetcalled && !paused && cameraexact)
+		thiscam->angle = R_PointToAngle2(thiscam->x, thiscam->y, viewpointx, viewpointy);
 
 	return (x == thiscam->x && y == thiscam->y && z == thiscam->z && angle == thiscam->aiming);
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -10701,12 +10701,53 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 	if (!camstill && !resetcalled && !paused && cameraexact)
 		thiscam->angle = R_PointToAngle2(thiscam->x, thiscam->y, viewpointx, viewpointy);
 
+	// romoney5: roblox-style camera clipping
 	if (camclipping == 2)
 	{
-		INT32 newx = thiscam->x, newy = thiscam->y;
+		INT32 targetx = thiscam->x, targety = thiscam->y, targetz = thiscam->z;
+
 		thiscam->x = mo->x;
 		thiscam->y = mo->y;
-		P_TryCameraMove(newx, newy, thiscam, true);
+		if (mo->eflags & MFE_VERTICALFLIP)
+			thiscam->z = mo->z + mo->height - pviewheight - camheight / 2; // romoney5: reverse height is very slightly inaccurate
+		else
+			thiscam->z = mo->z + pviewheight;
+
+		INT32 tryangle = R_PointToAngle2(thiscam->x, thiscam->y, targetx, targety);
+		INT32 trydist = R_PointToDist2(targetx, targety, thiscam->x, thiscam->y);
+		INT32 tryzangle = R_PointToAngle2(0, 0, trydist, -(thiscam->z - targetz));
+		trydist = R_PointToDist2(0, 0, trydist, thiscam->z - targetz);
+		
+		INT32 MAXTRYMOVE = FRACUNIT / 2;
+		INT32 movex = FixedMul(FINECOSINE((tryangle >> ANGLETOFINESHIFT) & FINEMASK), MAXTRYMOVE);
+		INT32 movey = FixedMul(FINESINE((tryangle >> ANGLETOFINESHIFT) & FINEMASK), MAXTRYMOVE);
+		INT32 movez = FixedMul(FINESINE((tryzangle >> ANGLETOFINESHIFT) & FINEMASK), MAXTRYMOVE);
+		movex = FixedMul(movex, FINECOSINE((tryzangle >> ANGLETOFINESHIFT) & FINEMASK));
+		movey = FixedMul(movey, FINECOSINE((tryzangle >> ANGLETOFINESHIFT) & FINEMASK));
+
+		for (INT32 moved = 0; moved < trydist; moved += MAXTRYMOVE) {
+			thiscam->x += movex;
+			thiscam->y += movey;
+			thiscam->z += movez;
+
+			// reached max distance
+			if (moved >= trydist)
+				break;
+
+			// one-side wall
+			if (!P_CheckCameraPosition(thiscam->x, thiscam->y, thiscam))
+				break; // solid wall or thing
+
+			if (tmceilingz - tmfloorz < thiscam->height)
+				break; // doesn't fit
+
+			if (tmceilingz - thiscam->z < thiscam->height)
+				break;
+
+			// floor
+			if ((tmfloorz - thiscam->z > 0))
+				return false; // too big a step up
+		}
 	}
 
 	return (x == thiscam->x && y == thiscam->y && z == thiscam->z && angle == thiscam->aiming);

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -10725,6 +10725,10 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		movex = FixedMul(movex, FINECOSINE((tryzangle >> ANGLETOFINESHIFT) & FINEMASK));
 		movey = FixedMul(movey, FINECOSINE((tryzangle >> ANGLETOFINESHIFT) & FINEMASK));
 
+		// hack; decrease the camera's radius
+		INT32 radius = thiscam->radius;
+		thiscam->radius = radius / 3;
+
 		for (INT32 moved = 0; moved < trydist; moved += MAXTRYMOVE) {
 			thiscam->x += movex;
 			thiscam->y += movey;
@@ -10746,8 +10750,10 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 
 			// floor
 			if ((tmfloorz - thiscam->z > 0))
-				return false; // too big a step up
+				break; // too big a step up
 		}
+
+		thiscam->radius = radius;
 	}
 
 	return (x == thiscam->x && y == thiscam->y && z == thiscam->z && angle == thiscam->aiming);

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9850,6 +9850,9 @@ consvar_t cv_cam2_orbit = CVAR_INIT ("cam2_orbit", "Off", CV_SAVE|CV_ALLOWLUA, C
 consvar_t cv_cam2_adjust = CVAR_INIT ("cam2_adjust", "On", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_earthquake = CVAR_INIT("earthquake", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
+consvar_t cv_cam_noclip = CVAR_INIT ("cam_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
+consvar_t cv_cam2_noclip = CVAR_INIT ("cam2_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
+
 
 // [standard vs simple][p1 or p2]
 consvar_t cv_cam_savedist[2][2] = {
@@ -9986,7 +9989,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		}
 	}
 
-	cameranoclip = (sign || player->powers[pw_carry] == CR_NIGHTSMODE || player->pflags & PF_NOCLIP) || (mo->flags & (MF_NOCLIP|MF_NOCLIPHEIGHT)); // Noclipping player camera noclips too!!
+	cameranoclip = (P_IsCameraNoclip(thiscam) || sign || player->powers[pw_carry] == CR_NIGHTSMODE || player->pflags & PF_NOCLIP) || (mo->flags & (MF_NOCLIP|MF_NOCLIPHEIGHT)); // Noclipping player camera noclips too!!
 
 	if (!(player->climbing || (player->powers[pw_carry] == CR_NIGHTSMODE) || player->playerstate == PST_DEAD || tutorialmode))
 	{

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9851,8 +9851,10 @@ consvar_t cv_cam2_adjust = CVAR_INIT ("cam2_adjust", "On", CV_SAVE|CV_ALLOWLUA, 
 consvar_t cv_earthquake = CVAR_INIT("earthquake", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 // romoney5: noclip camera
-consvar_t cv_cam_noclip = CVAR_INIT ("cam_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
-consvar_t cv_cam2_noclip = CVAR_INIT ("cam2_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
+static CV_PossibleValue_t clipping_cons_t[] = { {0, "Off"}, {1, "Vanilla"}, {2, "Exact"}, {0, NULL} };
+
+consvar_t cv_cam_clipping = CVAR_INIT ("cam_clipping", "Vanilla", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, clipping_cons_t, NULL);
+consvar_t cv_cam2_clipping = CVAR_INIT ("cam2_clipping", "Vanilla", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, clipping_cons_t, NULL);
 
 // romoney5: exact camera aiming
 consvar_t cv_cam_exact = CVAR_INIT ("cam_exact", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
@@ -9960,6 +9962,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 	fixed_t x, y, z, dist, distxy, distz, checkdist, viewpointx, viewpointy, camspeed, camdist, camheight, pviewheight, slopez = 0;
 	INT32 camrotate;
 	boolean camstill, cameranoclip, camorbit, cameraexact;
+	INT32 camclipping;
 	mobj_t *mo, *sign = NULL;
 	subsector_t *newsubsec;
 	fixed_t f1, f2;
@@ -10098,6 +10101,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		camheight = FixedMul(cv_cam_height.value, mo->scale);
 
 		cameraexact = cv_cam_exact.value;
+		camclipping = cv_cam_clipping.value;
 	}
 	else // Camera 2
 	{
@@ -10109,6 +10113,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		camheight = FixedMul(cv_cam2_height.value, mo->scale);
 
 		cameraexact = cv_cam2_exact.value;
+		camclipping = cv_cam2_clipping.value;
 	}
 
 	if (!cameraexact && P_CameraThinker(player, thiscam, resetcalled))
@@ -10695,6 +10700,14 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 
 	if (!camstill && !resetcalled && !paused && cameraexact)
 		thiscam->angle = R_PointToAngle2(thiscam->x, thiscam->y, viewpointx, viewpointy);
+
+	if (camclipping == 2)
+	{
+		INT32 newx = thiscam->x, newy = thiscam->y;
+		thiscam->x = mo->x;
+		thiscam->y = mo->y;
+		P_TryCameraMove(newx, newy, thiscam, true);
+	}
 
 	return (x == thiscam->x && y == thiscam->y && z == thiscam->z && angle == thiscam->aiming);
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -10264,7 +10264,8 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		if (!resetcalled && ((thiscam == &camera && cv_cam_adjust.value) || (thiscam == &camera2 && cv_cam2_adjust.value)))
 		{
 			if (!(mo->eflags & MFE_JUSTHITFLOOR) && (P_IsObjectOnGround(mo)) // Check that player is grounded
-			&& thiscam->ceilingz - thiscam->floorz >= P_GetPlayerHeight(player)) // Check that camera's sector is large enough for the player to fit into, at least
+			&& thiscam->ceilingz - thiscam->floorz >= P_GetPlayerHeight(player) // Check that camera's sector is large enough for the player to fit into, at least
+			&& thiscam->z >= thiscam->floorz && thiscam->z <= thiscam->ceilingz) // romoney5: if the camera is out of bounds, don't snap
 			{
 				if (mo->eflags & MFE_VERTICALFLIP) // if player is upside-down
 				{

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9850,6 +9850,7 @@ consvar_t cv_cam2_orbit = CVAR_INIT ("cam2_orbit", "Off", CV_SAVE|CV_ALLOWLUA, C
 consvar_t cv_cam2_adjust = CVAR_INIT ("cam2_adjust", "On", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_earthquake = CVAR_INIT("earthquake", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
+// romoney5: noclip camera
 consvar_t cv_cam_noclip = CVAR_INIT ("cam_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_cam2_noclip = CVAR_INIT ("cam2_noclip", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 
@@ -10488,7 +10489,8 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 
 		// camera fit?
 		if (myceilingz != myfloorz
-			&& myceilingz - thiscam->height < z)
+			&& myceilingz - thiscam->height < z
+			&& !cameranoclip)
 		{
 /*			// no fit
 			if (!resetcalled && !cameranoclip)

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9857,8 +9857,8 @@ consvar_t cv_cam_clipping = CVAR_INIT ("cam_clipping", "Vanilla", CV_SAVE|CV_ALL
 consvar_t cv_cam2_clipping = CVAR_INIT ("cam2_clipping", "Vanilla", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, clipping_cons_t, NULL);
 
 // romoney5: exact camera aiming
-consvar_t cv_cam_exact = CVAR_INIT ("cam_exact", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
-consvar_t cv_cam2_exact = CVAR_INIT ("cam2_exact", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
+consvar_t cv_cam_exact = CVAR_INIT ("cam_exact", "Off", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, CV_OnOff, NULL);
+consvar_t cv_cam2_exact = CVAR_INIT ("cam2_exact", "Off", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, CV_OnOff, NULL);
 
 
 // [standard vs simple][p1 or p2]

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -1736,6 +1736,9 @@ void R_RegisterEngineStuff(void)
 	CV_RegisterVar(&cv_cam_noclip);
 	CV_RegisterVar(&cv_cam2_noclip);
 
+	CV_RegisterVar(&cv_cam_exact);
+	CV_RegisterVar(&cv_cam2_exact);
+
 	CV_RegisterVar(&cv_cam_savedist[0][0]);
 	CV_RegisterVar(&cv_cam_savedist[0][1]);
 	CV_RegisterVar(&cv_cam_savedist[1][0]);

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -1733,6 +1733,9 @@ void R_RegisterEngineStuff(void)
 	CV_RegisterVar(&cv_cam2_orbit);
 	CV_RegisterVar(&cv_cam2_adjust);
 
+	CV_RegisterVar(&cv_cam_noclip);
+	CV_RegisterVar(&cv_cam2_noclip);
+
 	CV_RegisterVar(&cv_cam_savedist[0][0]);
 	CV_RegisterVar(&cv_cam_savedist[0][1]);
 	CV_RegisterVar(&cv_cam_savedist[1][0]);

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -1733,8 +1733,8 @@ void R_RegisterEngineStuff(void)
 	CV_RegisterVar(&cv_cam2_orbit);
 	CV_RegisterVar(&cv_cam2_adjust);
 
-	CV_RegisterVar(&cv_cam_noclip);
-	CV_RegisterVar(&cv_cam2_noclip);
+	CV_RegisterVar(&cv_cam_clipping);
+	CV_RegisterVar(&cv_cam2_clipping);
 
 	CV_RegisterVar(&cv_cam_exact);
 	CV_RegisterVar(&cv_cam2_exact);


### PR DESCRIPTION
This adds two new console variables: `cam_exact` and `cam_clipping`.

`cam_exact` (off by default) changes the camera's behavior to be more precise with camera inputs. Aiming now follows the exact direction and movement is generally less laggy than vanilla.
Off:
<img width="384" height="216" alt="srb23986" src="https://github.com/user-attachments/assets/7c710723-6fb2-49b2-9c7b-5af1f7b7de0e" />
On:
<img width="384" height="216" alt="srb23988" src="https://github.com/user-attachments/assets/ba6b3785-8a67-473b-a4c5-e1762473357a" />

`cam_clipping` (Vanilla by default) has three new options:
- `Off` disables camera clipping entirely. Note that looking through walls may cause visual glitches.
<img width="384" height="216" alt="srb23990" src="https://github.com/user-attachments/assets/7840c2ba-4c34-4bbe-a53a-07aaef4d1f72" />

- `Vanilla` uses standard camera clipping. It uses mobj-like physics and is sometimes pretty buggy.
<img width="384" height="216" alt="srb23991" src="https://github.com/user-attachments/assets/56f743de-ddca-4d83-af43-677cba2f405c" />

- `Exact` reworks the clipping system to instead clip based on a "raycast" from the player's position (in steps of FRACUNIT / 2), giving a Roblox-like style.
<img width="384" height="216" alt="srb23993" src="https://github.com/user-attachments/assets/e3bf2f01-d056-4dab-a0cf-0deed8255490" />


Both variables have splitscreen variants.