### PR TITLE
remove leftovers from rasin merge

### DIFF
--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -110,7 +110,6 @@ static patch_t *nopingicon;
 
 // crosshair 0 = off, 1 = cross, 2 = angle, 3 = point, see m_menu.c
 static patch_t *crosshair[HU_CROSSHAIRS]; // 3 precached crosshair graphics
-static patch_t *crosshair_inverted[HU_CROSSHAIRS]; // 3 precached crosshair graphics for subtractive blending
 
 // Show PMs (if host), yoinked from Classic.
 static consvar_t cv_showprivatemessages = CVAR_INIT ("hu_showprivatemessages", "Yes", CV_SAVE|CV_CLIENT|CV_NOSHOWHELP, CV_YesNo, NULL);
@@ -234,9 +233,6 @@ void HU_LoadGraphics(void)
 	{
 		sprintf(buffer, "CROSHAI%c", '1'+i);
 		crosshair[i] = (patch_t *)W_CachePatchName(buffer, PU_HUDGFX);
-
-		sprintf(buffer, "CRSHAII%c", '1'+i);
-		crosshair_inverted[i] = (patch_t *)W_CachePatchName(buffer, PU_HUDGFX);
 	}
 
 	emblemicon = W_CachePatchName("EMBLICON", PU_HUDGFX);

--- a/src/lua_script.c
+++ b/src/lua_script.c
@@ -443,9 +443,6 @@ int LUA_PushGlobals(lua_State *L, const char *word)
 	} else if (fastcmp(word, "chatactive")) {
 		lua_pushboolean(L, chat_on);
 		return 1;
-	} else if (fastcmp(word, "rasinbuild")) {
-		lua_pushboolean(L, true);
-		return 1;
 	}
 
 	if (GKS_PushGlobals(L, word))


### PR DESCRIPTION
inverted crosshair patch caching was also merged in on commit 7d5b220eb439b9453d662b97d387bfa9294d0d36 but not reverted
this pr also removes the rasinbuild global