### PR TITLE
Port `cv_gamepadifunfocused` from SRB2Kart Saturn

### DIFF
--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -560,6 +560,8 @@ const char *I_GetJoyName(INT32 joyindex)
 	return NULL;
 }
 
+void I_SetJoystickFocus(void){}
+
 #ifndef NOMUMBLE
 #ifdef HAVE_MUMBLE
 // Best Mumble positional audio settings:

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -32,6 +32,7 @@ consvar_t cv_mousesens2 = CVAR_INIT ("mousesens2", "20", CV_SAVE, mousesens_cons
 consvar_t cv_mouseysens = CVAR_INIT ("mouseysens", "20", CV_SAVE, mousesens_cons_t, NULL);
 consvar_t cv_mouseysens2 = CVAR_INIT ("mouseysens2", "20", CV_SAVE, mousesens_cons_t, NULL);
 consvar_t cv_controlperkey = CVAR_INIT ("controlperkey", "One", CV_SAVE, onecontrolperkey_cons_t, NULL);
+consvar_t cv_gamepadifunfocused = CVAR_INIT ("gamepadunfocused", "Off", CV_SAVE|CV_CALL|CV_CLIENT, CV_OnOff, NULL);
 
 mouse_t mouse;
 mouse_t mouse2;

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -20,6 +20,7 @@
 #include "console.h"
 #include "lua_script.h"
 #include "lua_libs.h"
+#include "i_system.h" // I_SetJoystickFocus
 
 #define MAXMOUSESENSITIVITY 100 // sensitivity steps
 
@@ -32,7 +33,7 @@ consvar_t cv_mousesens2 = CVAR_INIT ("mousesens2", "20", CV_SAVE, mousesens_cons
 consvar_t cv_mouseysens = CVAR_INIT ("mouseysens", "20", CV_SAVE, mousesens_cons_t, NULL);
 consvar_t cv_mouseysens2 = CVAR_INIT ("mouseysens2", "20", CV_SAVE, mousesens_cons_t, NULL);
 consvar_t cv_controlperkey = CVAR_INIT ("controlperkey", "One", CV_SAVE, onecontrolperkey_cons_t, NULL);
-consvar_t cv_gamepadifunfocused = CVAR_INIT ("gamepadunfocused", "Off", CV_SAVE|CV_CALL|CV_CLIENT, CV_OnOff, NULL);
+consvar_t cv_gamepadifunfocused = CVAR_INIT ("gamepadunfocused", "Off", CV_SAVE|CV_CALL|CV_CLIENT, CV_OnOff, I_SetJoystickFocus);
 
 mouse_t mouse;
 mouse_t mouse2;

--- a/src/g_input.h
+++ b/src/g_input.h
@@ -119,6 +119,7 @@ typedef enum
 extern consvar_t cv_mousesens, cv_mouseysens;
 extern consvar_t cv_mousesens2, cv_mouseysens2;
 extern consvar_t cv_controlperkey;
+extern consvar_t cv_gamepadifunfocused;
 
 typedef struct
 {

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -189,6 +189,8 @@ INT32 I_NumJoys(void);
 */
 const char *I_GetJoyName(INT32 joyindex);
 
+void I_SetJoystickFocus(void);
+
 #ifndef NOMUMBLE
 #include "p_mobj.h" // mobj_t
 #include "s_sound.h" // listener_t

--- a/src/netcode/d_netcmd.c
+++ b/src/netcode/d_netcmd.c
@@ -867,6 +867,7 @@ void D_RegisterClientCommands(void)
 	CV_RegisterVar(&cv_deadzone2);
 	CV_RegisterVar(&cv_digitaldeadzone);
 	CV_RegisterVar(&cv_digitaldeadzone2);
+	CV_RegisterVar(&cv_gamepadifunfocused);
 
 	// filesrch.c
 	//CV_RegisterVar(&cv_addons_option); // These two are now defined

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1338,6 +1338,11 @@ static int joy_open(int joyindex)
 	}
 }
 
+void I_SetJoystickFocus(void)
+{
+	SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, cv_gamepadifunfocused.value ? "1" : "0");
+}
+
 //Joystick2
 
 /**	\brief Joystick 2 buttons states


### PR DESCRIPTION
this is probably not gonna be used by anyone so im unsure if i should even pr or not
doing so just in case

the cvar name says it all, when enabled, SRB2 will still recognize controller inputs even when the window isnt focused