### PR TITLE
Fix Software sprite brightness with r_secbright (Fixes #7)

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -1294,7 +1294,7 @@ static void R_SplitSprite(vissprite_t *sprite)
 		newsprite->cut |= SC_TOP;
 		if (!(sector->lightlist[i].caster->fofflags & FOF_NOSHADE))
 		{
-			lightnum = max((*sector->lightlist[i].lightlevel >> LIGHTSEGSHIFT), cv_secbright.value);
+			lightnum = max(*sector->lightlist[i].lightlevel, cv_secbright.value) >> LIGHTSEGSHIFT;
 
 			if (lightnum < 0)
 				spritelights = scalelight[0];
@@ -2310,7 +2310,7 @@ static void R_ProjectSprite(mobj_t *thing)
 	{
 		light = P_GetSectorLightNumAt(thing->subsector->sector, interp.x, interp.y, splat ? gz : gzt);
 
-		INT32 lightnum = max((*thing->subsector->sector->lightlist[light].lightlevel >> LIGHTSEGSHIFT), cv_secbright.value);
+		INT32 lightnum = max(*thing->subsector->sector->lightlist[light].lightlevel, cv_secbright.value) >> LIGHTSEGSHIFT;
 		if (lightnum < 0)
 			spritelights = scalelight[0];
 		else if (lightnum >= LIGHTLEVELS)
@@ -2700,7 +2700,7 @@ void R_AddSprites(sector_t *sec, INT32 lightlevel)
 	{
 		if (sec->heightsec == -1) lightlevel = sec->lightlevel;
 
-		lightnum = max((lightlevel >> LIGHTSEGSHIFT), cv_secbright.value);
+		lightnum = max(lightlevel, cv_secbright.value) >> LIGHTSEGSHIFT;
 
 		if (lightnum < 0)
 			spritelights = scalelight[0];


### PR DESCRIPTION
The issue was caused by incorrect logic placement.

Before:
<img width="384" height="216" alt="srb24443" src="https://github.com/user-attachments/assets/993e076b-26e6-4bd1-a843-0ab87b25faa2" />

After:
<img width="384" height="216" alt="srb24444" src="https://github.com/user-attachments/assets/e2a1bbaa-7207-48ed-9a4a-5bb59478c72d" />