### PR TITLE
Disable exact camera clipping in 2D mode

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -10695,7 +10695,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 		thiscam->angle = R_PointToAngle2(thiscam->x, thiscam->y, viewpointx, viewpointy);
 
 	// romoney5: roblox-style camera clipping
-	if (camclipping == 2)
+	if (camclipping == 2 && !(twodlevel || (mo->flags2 & MF2_TWOD)))
 	{
 		INT32 targetx = thiscam->x, targety = thiscam->y, targetz = thiscam->z;
 


### PR DESCRIPTION
Fixes a long-standing oversight with exact camera clipping.

Before:
<img width="384" height="216" alt="srb24674" src="https://github.com/user-attachments/assets/6960c891-6459-485e-afe6-942fd6464840" />

After:
<img width="384" height="216" alt="srb24675" src="https://github.com/user-attachments/assets/4be01a69-f7e4-438c-9ff8-4014b13aeb84" />
