### PR TITLE
Go to the title instead of I_Erroring on savegame errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ It works without any additional assets, just copy the build to your existing SRB
 
 ## Gameplay / Netplay
 - Skin change at any time
+- Savegame errors return to the title screen
 - Addfilelocal from SRB2K Saturn! (use "`addfilelocal`" command or press R-ALT in the addons menu)
 - Minimum input delay from SRB2Kart Saturn/Ring Racers! ("`mindelay`")
 - Improved startup times! (Code from [SRB2Classic](https://codeberg.org/srb2classic/srb2classic))

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -206,9 +206,6 @@ static void M_RoomMenu(INT32 choice);
 // NEEDED FUNCTION PROTOTYPES GO HERE
 // ==========================================================================
 
-// the haxor message menu
-menu_t MessageDef;
-
 menu_t SPauseDef;
 
 // Level Select

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -367,6 +367,9 @@ extern menu_t *currentMenu;
 extern menu_t MainDef;
 extern menu_t SP_LoadDef;
 
+// the haxor message menu
+extern menu_t MessageDef;
+
 // Call upon joystick hotplug
 void M_SetupJoystickMenu(INT32 choice);
 extern menu_t OP_JoystickSetDef;

--- a/src/netcode/client_connection.c
+++ b/src/netcode/client_connection.c
@@ -1535,8 +1535,8 @@ static boolean CL_ServerConnectionTicker(const char *tmpsave, tic_t *oldtic, tic
 			if (fileneeded[0].status == FS_FOUND)
 			{
 				// Gamestate is now handled within CL_LoadReceivedSavegame()
-				CL_LoadReceivedSavegame(false);
-				cl_mode = CL_CONNECTED;
+				if (CL_LoadReceivedSavegame(false))
+					cl_mode = CL_CONNECTED;
 			} // don't break case continue to CL_CONNECTED
 			else
 				break;
@@ -1654,9 +1654,14 @@ static boolean CL_ServerConnectionTicker(const char *tmpsave, tic_t *oldtic, tic
 		if (gamekeydown[KEY_ESCAPE] || gamekeydown[KEY_JOY1+1] || cl_mode == CL_ABORTED)
 		{
 			CONS_Printf(M_GetText("Network game synchronization aborted.\n"));
-			M_StartMessage(M_GetText("Network game synchronization aborted.\n\nPress ESC\n"), NULL, MM_NOTHING);
+			// M_StartMessage(M_GetText("Network game synchronization aborted.\n\nPress ESC\n"), NULL, MM_NOTHING);
+
+			menu_t *menu = currentMenu;
 
 			AbortConnection();
+
+			if (menu == &MessageDef)
+				currentMenu = &MessageDef;
 
 			memset(gamekeydown, 0, NUMKEYS);
 			return false;

--- a/src/netcode/gamestate.c
+++ b/src/netcode/gamestate.c
@@ -34,6 +34,7 @@
 #include "../r_main.h"
 #include "../tables.h"
 #include "../z_zone.h"
+#include <stdbool.h>
 #if defined (__GNUC__) || defined (__unix__)
 #include <unistd.h>
 #endif
@@ -153,11 +154,12 @@ void SV_SavedGame(void)
 #define TMPSAVENAME "$$$.sav"
 
 
-void CL_LoadReceivedSavegame(boolean reloading)
+boolean CL_LoadReceivedSavegame(boolean reloading)
 {
 	save_t savebuffer;
 	size_t decompressedlen;
 	char tmpsave[256];
+	boolean succeeded = true;
 
 	FreeFileNeeded();
 
@@ -170,7 +172,7 @@ void CL_LoadReceivedSavegame(boolean reloading)
 	if (!savebuffer.size)
 	{
 		I_Error("Can't read savegame sent");
-		return;
+		return false;
 	}
 
 	// Decompress saved game if necessary.
@@ -192,7 +194,7 @@ void CL_LoadReceivedSavegame(boolean reloading)
 	automapactive = false;
 
 	// load a base level
-	if (P_LoadNetGame(&savebuffer, reloading))
+	if ((succeeded = P_LoadNetGame(&savebuffer, reloading)))
 	{
 		const UINT8 actnum = mapheaderinfo[gamemap-1]->actnum;
 		CONS_Printf(M_GetText("Map is now \"%s"), G_BuildMapName(gamemap));
@@ -220,6 +222,8 @@ void CL_LoadReceivedSavegame(boolean reloading)
 	// so they know they can resume the game
 	netbuffer->packettype = PT_RECEIVEDGAMESTATE;
 	HSendPacket(servernode, true, 0, 0);
+
+	return succeeded;
 }
 
 void CL_ReloadReceivedSavegame(void)

--- a/src/netcode/gamestate.h
+++ b/src/netcode/gamestate.h
@@ -21,7 +21,7 @@ extern boolean cl_redownloadinggamestate;
 boolean SV_ResendingSavegameToAnyone(void);
 void SV_SendSaveGame(INT32 node, boolean resending);
 void SV_SavedGame(void);
-void CL_LoadReceivedSavegame(boolean reloading);
+boolean CL_LoadReceivedSavegame(boolean reloading);
 void CL_ReloadReceivedSavegame(void);
 void Command_ResendGamestate(void);
 void PT_CanReceiveGamestate(SINT8 node);

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -16,8 +16,10 @@
 #include "d_main.h"
 #include "doomstat.h"
 #include "g_game.h"
+#include "m_menu.h"
 #include "m_random.h"
 #include "m_misc.h"
+#include "netcode/client_connection.h"
 #include "p_local.h"
 #include "p_setup.h"
 #include "p_saveg.h"
@@ -36,6 +38,7 @@
 #include "lua_script.h"
 #include "p_slopes.h"
 #include "hu_stuff.h"
+#include <locale.h>
 
 savedata_t savedata;
 
@@ -278,6 +281,38 @@ void P_ReadMem(save_t *p, void *s, size_t n)
 	memcpy(s, &p->buf[p->pos], n);
 	p->pos += n;
 }
+
+static extracolormap_t *net_colormaps = NULL;
+static UINT32 num_net_colormaps = 0;
+static UINT32 num_ffloors = 0; // for loading
+
+// romoney5: for more common savegame errors, just return to the title screen
+// and print a helpful message
+static boolean save_errored = false;
+
+static void SaveError(const char *str, ...)
+{
+	va_list argptr;
+	char buffer[512];
+
+	va_start(argptr, str);
+	vsprintf(buffer, str, argptr);
+	va_end(argptr);
+
+	save_errored = true;
+
+	// Don't need these anymore
+	num_net_colormaps = 0;
+	num_ffloors = 0;
+	net_colormaps = NULL;
+	
+	Command_ExitGame_f();
+	CONS_Printf("%s\n", buffer);
+	M_StartMessage(va("%s\n\nPress ESC\n", buffer), NULL, MM_NOTHING);
+	cl_mode = CL_ABORTED;
+}
+
+#define CHECKSAVEERR() if (save_errored) {save_errored = false; return false;}
 
 // Block UINT32s to attempt to ensure that the correct data is
 // being sent and received
@@ -814,10 +849,6 @@ static void P_NetUnArchivePlayers(save_t *save_p)
 ///
 /// Colormaps
 ///
-
-static extracolormap_t *net_colormaps = NULL;
-static UINT32 num_net_colormaps = 0;
-static UINT32 num_ffloors = 0; // for loading
 
 // Copypasta from r_data.c AddColormapToList
 // But also check for equality and return the matching index
@@ -1475,7 +1506,12 @@ static void UnArchiveSectors(save_t *save_p)
 			break;
 
 		if (i > numsectors)
-			I_Error("Invalid sector number %u from server (expected end at %s)", i, sizeu1(numsectors));
+		{
+			// SaveError("Invalid sector number %u from server (expected end at %s)", i, sizeu1(numsectors));
+			CONS_Alert(CONS_ERROR, "Invalid sector number %u from server (expected end at %s)\n", i, sizeu1(numsectors));
+			SaveError("Invalid sector number in savegame.\nCheck the console for details.", i);
+			return;
+		}
 
 		diff = P_ReadUINT8(save_p);
 		if (diff & SD_DIFF2)
@@ -1882,8 +1918,14 @@ static void UnArchiveLines(save_t *save_p)
 
 		if (i == 0xffffffff)
 			break;
+
 		if (i > numlines)
-			I_Error("Invalid line number %u from server", i);
+		{
+			// SaveError("Invalid line number %u from server", i);
+			CONS_Alert(CONS_ERROR, "Invalid line number %u from server\n", i);
+			SaveError("Invalid line number in savegame.\nCheck the console for details.", i);
+			return;
+		}
 
 		diff = P_ReadUINT8(save_p);
 		if (diff & LD_DIFF2)
@@ -3331,7 +3373,11 @@ static thinker_t* LoadMobjThinker(save_t *save_p, actionf_p1 thinker)
 				CONS_Alert(CONS_ERROR, "Found mobj with unknown map thing type %d\n", mobj->spawnpoint->type);
 			else
 				CONS_Alert(CONS_ERROR, "Found mobj with unknown map thing type NULL\n");
-			I_Error("Savegame corrupted");
+
+			// SaveError("Savegame corrupted");
+			SaveError("Found a mobj with an unknown thing type.\nCheck the console for details.");
+
+			return NULL;
 		}
 		mobj->type = i;
 	}
@@ -4396,10 +4442,12 @@ static void P_NetUnArchiveThinkers(save_t *save_p)
 					break;
 
 				default:
-					I_Error("P_UnarchiveSpecials: Unknown tclass %d in savegame", tclass);
+					I_Error("P_NetUnArchiveThinkers: Unknown tclass %d in savegame", tclass);
 			}
 			if (th)
 				P_AddThinker(i, th);
+			else
+				return;
 		}
 
 		CONS_Debug(DBG_NETPLAY, "%u thinkers loaded in list %d\n", numloaded, i);
@@ -4512,7 +4560,11 @@ FUNCINLINE static ATTRINLINE void P_UnArchivePolyObjects(save_t *save_p)
 	numSavedPolys = P_ReadINT32(save_p);
 
 	if (numSavedPolys != numPolyObjects)
-		I_Error("P_UnArchivePolyObjects: polyobj count inconsistency\n");
+	{
+		// I_Error("P_UnArchivePolyObjects: polyobj count inconsistency\n");
+		CONS_Alert(CONS_ERROR, "P_UnArchivePolyObjects: polyobj count inconsistency (expected %d, got %d)\n", numPolyObjects, numSavedPolys);
+		SaveError("Invalid PolyObject count in savegame.\nCheck the console for details.");
+	}
 
 	for (i = 0; i < numSavedPolys; ++i)
 		P_UnArchivePolyObj(save_p, &PolyObjects[i]);
@@ -5429,8 +5481,11 @@ boolean P_LoadNetGame(save_t *save_p, boolean reloading)
 	if (gamestate == GS_LEVEL)
 	{
 		P_NetUnArchiveWorld(save_p);
+		CHECKSAVEERR()
 		P_UnArchivePolyObjects(save_p);
+		CHECKSAVEERR()
 		P_NetUnArchiveThinkers(save_p);
+		CHECKSAVEERR()
 		P_NetUnArchiveSpecials(save_p);
 		P_NetUnArchiveColormaps(save_p);
 		P_NetUnArchiveWaypoints(save_p);


### PR DESCRIPTION
Kicks you back to the title screen instead of closing the game when a savegame error occurs.
Also makes the error messages more descriptive for the end-user.

This only takes effect on more common errors like:
Invalid sector number %u from server
Invalid line number %u from server
Savegame corrupted
polyobj count inconsistency

<img width="384" height="216" alt="srb24768" src="https://github.com/user-attachments/assets/cd1a73c2-4a76-4e71-87b0-cbdab9870b64" />