### PR TITLE
`HMS_fetch_servers`: Walk around !1455

### DIFF
--- a/src/netcode/http-mserv.c
+++ b/src/netcode/http-mserv.c
@@ -756,8 +756,7 @@ HMS_fetch_servers (msg_server_t *list, int room_number, int query_id)
 				}
 				else
 				{
-					section_end = 0;/* malformed so quit the parsing */
-					break;
+					continue;
 				}
 			}
 

--- a/src/netcode/http-mserv.c
+++ b/src/netcode/http-mserv.c
@@ -748,19 +748,11 @@ HMS_fetch_servers (msg_server_t *list, int room_number, int query_id)
 
 						i++;
 					}
-
-					if (end == section_end)/* end of list for this room */
-						break;
-					else
-						p = ( end + 1 );/* skip server delimiter */
 				}
-				else
-				{
-					if (end == section_end)/* end of list for this room */
-						break;
-					else
-						p = ( end + 1 );/* skip server delimiter */
-				}
+                if (end == section_end)/* end of list for this room */
+                    break;
+                else
+                    p = ( end + 1 );/* skip server delimiter */
 			}
 
 			if (! doing_shit)

--- a/src/netcode/http-mserv.c
+++ b/src/netcode/http-mserv.c
@@ -756,7 +756,10 @@ HMS_fetch_servers (msg_server_t *list, int room_number, int query_id)
 				}
 				else
 				{
-					continue;
+					if (end == section_end)/* end of list for this room */
+						break;
+					else
+						p = ( end + 1 );/* skip server delimiter */
 				}
 			}
 


### PR DESCRIPTION
This has already been PR'd to upstream as of writing ([MR !2781](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2781))

~~I have a slowly creeping feeling that I'm forgetting something; assuming the data afterwards is also malformed at any point, it should still just skip it, so it SHOULD be fine.~~ EDIT: p should've been advanced so some servers weren't showing... This was fixed with extremely lazy codeduping

<img width="3816" height="1084" alt="image" src="https://github.com/user-attachments/assets/d0d4854b-f441-4611-a8a6-34e1b84e2630" />
(Left: this PR; Right: `master`. Note that though the sorting is different, the amount of pages and servers should say enough)

For reference, this is the original problem:
<img width="1246" height="909" alt="image" src="https://github.com/user-attachments/assets/a50b5ac1-910e-49ba-aefe-60419c42f37b" />

PS: This causes any server that hits it to not be shown, but that's definitely way better than not seeing every single server thereafter.