### PR TITLE
Port help command features back in

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Icon credits goes to ClovesCloestarSRB2 and his addon [New Springs](https://mb.s
 - Fixed chats not being saved on the logs in Linux systems
 - Removed 5-second delay upon disconnecting from servers
 - Fixed "All" Room not fetching properly.
+- The `help` command is now sorted by origin (Vanilla, Banpyura, Addon). You can use `-v`, `-c`, and `-a` respectively to only print out only those sections. (You can use more than one flag at once).
+- Doing merely `<cvar>` has the same effect as `help <cvar>`.
+- Console variable information is more in-depth.
+- - You can choose to hide certain sections via `cvarinfo` ("Show All" by default).
 
 **Most of these options can be found in the menu under Banpyura Options....**
 

--- a/src/command.c
+++ b/src/command.c
@@ -993,7 +993,7 @@ static void COM_Help_f(void)
 		isitallfalse = (!parmv && !parmc && !parma);
 
 		// slightly less ternary spam
-		const char* helpheaders[] = {"Vanilla:", "Client:", "Addon:"};
+		const char* helpheaders[] = {"Vanilla:", "Banpyura:", "Addon:"};
 
 		while (oi <= 2)
 		{

--- a/src/command.c
+++ b/src/command.c
@@ -46,6 +46,7 @@
 //========
 static boolean COM_Exists(const char *com_name);
 static void COM_ExecuteString(char *com_text);
+static void CV_Info(consvar_t *v);
 
 static void COM_Alias_f(void);
 static void COM_Echo_f(void);
@@ -55,6 +56,7 @@ static void COM_CEchoDuration_f(void);
 static void COM_Exec_f(void);
 static void COM_Wait_f(void);
 static void COM_Help_f(void);
+static void COM_CONSLogicC_f(void);
 static void COM_Find_f(void);
 static void COM_Toggle_f(void);
 static void COM_Add_f(void);
@@ -354,6 +356,7 @@ void COM_Init(void)
 	COM_AddCommand("exec", COM_Exec_f, 0);
 	COM_AddCommand("wait", COM_Wait_f, 0);
 	COM_AddCommand("help", COM_Help_f, COM_LUA);
+	COM_AddCommand("consolelogiccount", COM_CONSLogicC_f, COM_CLIENT);
 	COM_AddCommand("find", COM_Find_f, COM_LUA);
 	COM_AddCommand("toggle", COM_Toggle_f, COM_LUA);
 	COM_AddCommand("add", COM_Add_f, COM_LUA);
@@ -558,7 +561,7 @@ int COM_AddLuaCommand(const char *name)
 	cmd = ZZ_Alloc(sizeof *cmd);
 	cmd->name = name;
 	cmd->function = COM_Lua_f;
-	cmd->flags = COM_LUA;
+	cmd->flags = COM_LUA|COM_LUACOM;
 	cmd->next = com_commands;
 	com_commands = cmd;
 	return 0;
@@ -885,149 +888,209 @@ static void COM_Wait_f(void)
 		com_wait = 1; // 1 frame
 }
 
-/** Prints help on variables and commands.
-  */
+// Prints help on variables and commands.
 static void COM_Help_f(void)
 {
 	xcommand_t *cmd;
 	consvar_t *cvar;
-	INT32 i = 0;
+	// Params for only showing certain origins (NOT type)
+	boolean parmv = COM_CheckPartialParm("-v");
+	boolean parmc = COM_CheckPartialParm("-c");
+	boolean parma = COM_CheckPartialParm("-a");
+	// is the current loop for commands? (iscomloop)
+	// did we even hit any CV_LUAVAR/COM_LUACOM? (foundflag)
+	boolean iscomloop = false, foundflag = false, isitallfalse = false;
 
-	if (COM_Argc() > 1)
+	// Okay, bear with me here: It aligns ingame.
+	if (COM_CheckPartialParm("-f")) {
+
+		CONS_Printf("CV_SAVE\t\t\t | This variable saves to config.\n");
+		CONS_Printf("CV_CALL\t\t\t | Calls a function on change.\n");
+		CONS_Printf("CV_NETVAR\t\t\t | Sent to all connected clients on change.\n");
+		CONS_Printf("CV_NOINIT\t\t\t | Don't call functions when registered.\n");
+		CONS_Printf("CV_FLOAT\t\t\t | Fixed 16 bits (int and frac), unit is FRACUNIT. Value is converted in possible values.\n");
+		CONS_Printf("CV_NOTINNET\t\t | Can't be changed in netgames, however ISN'T a netvar.\n");
+		CONS_Printf("CV_MODIFIED\t\t | This variable was modified.\n");
+		CONS_Printf("CV_SHOWMODIF\t\t | Show something when modified.\n");
+		CONS_Printf("CV_SHOWMODIFONETIME | Same as CV_SHOWMODIF, except is removed afterwards.\n");
+		CONS_Printf("CV_NOSHOWHELP\t\t | Does not appear in help list.\n");
+		// CV_HIDEN is unnecessary as those vars are outside the console
+		CONS_Printf("CV_CHEAT\t\t\t | Can only be used if cheats are enabled.\n");
+		CONS_Printf("CV_ALLOWLUA\t\t | Lua can call this console variable.\n");
+		CONS_Printf("CV_LUAVAR\t\t\t | This console variable was made by Lua.\n");
+		CONS_Printf("CV_CLIENT\t\t\t | Variable is not in vanilla SRB2.\n");
+		CONS_Printf("Commands with COM_LUA can be executed by Lua. Command flags are self-explanatory.\n");
+		return;
+	} 
+
+	if (COM_Argc() > 1 && !(parmv || parmc || parma))
 	{
 		const char *help = COM_Argv(1);
 		cvar = CV_FindVar(help);
-		if (cvar)
-		{
-			boolean floatmode = false;
-			const char *cvalue = NULL;
-			CONS_Printf("\x82""Variable %s:\n", cvar->name);
-			CONS_Printf(M_GetText("  flags: "));
-			if (cvar->flags & CV_SAVE)
-				CONS_Printf("AUTOSAVE ");
-			if (cvar->flags & CV_FLOAT)
-			{
-				CONS_Printf("FLOAT ");
-				floatmode = true;
-			}
-			if (cvar->flags & CV_NETVAR)
-				CONS_Printf("NETVAR ");
-			if (cvar->flags & CV_CALL)
-				CONS_Printf("ACTION ");
-			if (cvar->flags & CV_CHEAT)
-				CONS_Printf("CHEAT ");
-			CONS_Printf("\n");
-			if (cvar->PossibleValue)
-			{
-				CONS_Printf(" Possible values:\n");
-				if (cvar->PossibleValue == CV_YesNo)
-					CONS_Printf("  Yes or No (On or Off, True or False, 1 or 0)\n");
-				else if (cvar->PossibleValue == CV_OnOff)
-					CONS_Printf("  On or Off (Yes or No, True or False, 1 or 0)\n");
-				else if (cvar->PossibleValue == CV_TrueFalse)
-					CONS_Printf("  True or False (On or Off, Yes or No, 1 or 0)\n");
-				else if (cvar->PossibleValue == Color_cons_t)
-				{
-					for (i = 1; i < numskincolors; ++i)
-					{
-						if (skincolors[i].accessible)
-						{
-							CONS_Printf("  %-2d : %s\n", i, skincolors[i].name);
-							if (i == cvar->value)
-								cvalue = skincolors[i].name;
-						}
-					}
-				}
-				else
-				{
-#define MINVAL 0
-#define MAXVAL 1
-					if (!stricmp(cvar->PossibleValue[MINVAL].strvalue, "MIN"))
-					{
-						if (floatmode)
-						{
-							float fu = FIXED_TO_FLOAT(cvar->PossibleValue[MINVAL].value);
-							float ck = FIXED_TO_FLOAT(cvar->PossibleValue[MAXVAL].value);
-							CONS_Printf("  range from %ld%s to %ld%s\n",
-									(long)fu, M_Ftrim(fu),
-									(long)ck, M_Ftrim(ck));
-						}
-						else
-							CONS_Printf("  range from %d to %d\n", cvar->PossibleValue[MINVAL].value,
-								cvar->PossibleValue[MAXVAL].value);
-						i = MAXVAL+1;
-					}
-#undef MINVAL
-#undef MAXVAL
-
-					//CONS_Printf(M_GetText("  possible value : %s\n"), cvar->name);
-					while (cvar->PossibleValue[i].strvalue)
-					{
-						if (floatmode)
-							CONS_Printf("  %-2f : %s\n", FIXED_TO_FLOAT(cvar->PossibleValue[i].value),
-								cvar->PossibleValue[i].strvalue);
-						else
-							CONS_Printf("  %-2d : %s\n", cvar->PossibleValue[i].value,
-								cvar->PossibleValue[i].strvalue);
-						if (cvar->PossibleValue[i].value == cvar->value)
-							cvalue = cvar->PossibleValue[i].strvalue;
-						i++;
-					}
-				}
-			}
-
-			if (cvalue)
-				CONS_Printf(" Current value: %s\n", cvalue);
-			else if (cvar->string)
-				CONS_Printf(" Current value: %s\n", cvar->string);
-			else
-				CONS_Printf(" Current value: %d\n", cvar->value);
-
-			if (cvar->revert.v.string != NULL && strcmp(cvar->revert.v.string, cvar->string) != 0)
-				CONS_Printf(" Value before netgame: %s\n", cvar->revert.v.string);
-		}
-		else
-		{
+		if (cvar) {
+			CV_Info(cvar);
+			return;
+		} else {
 			for (cmd = com_commands; cmd; cmd = cmd->next)
 			{
 				if (strcmp(cmd->name, help))
 					continue;
 
 				CONS_Printf("\x82""Command %s:\n", cmd->name);
-				CONS_Printf("  help is not available for commands");
-				CONS_Printf("\x82""\nCheck wiki.srb2.org for more or try typing <name> without arguments\n");
+				if (!(cv_cvarinformation.value == 2 || cv_cvarinformation.value == 3))
+				{
+					CONS_Printf(M_GetText("  flags: "));
+
+					// fixme: enough said vvv
+					if (cmd->flags & COM_ADMIN)
+						CONS_Printf("COM_ADMIN ");
+
+					if (cmd->flags & COM_LOCAL)
+						CONS_Printf("COM_LOCAL ");
+
+					if (cmd->flags & COM_LUA)
+						CONS_Printf("COM_LUA ");
+
+					if (cmd->flags & COM_LUACOM)
+						CONS_Printf("COM_LUACOM ");
+
+					if (cmd->flags & COM_CLIENT)
+						CONS_Printf("COM_CLIENT ");
+
+					if (cmd->flags & COM_SPLITSCREEN)
+						CONS_Printf("COM_SPLITSCREEN");
+				
+					CONS_Printf("\n");
+				}
+
+				if (!(cv_cvarinformation.value == 1 || cv_cvarinformation.value == 3))
+				{
+					if (!(cmd->flags & (COM_LUACOM | COM_CLIENT))) {
+						CONS_Printf("\tOrigin: Vanilla""\x82"" (Check wiki.srb2.org for more information)\n");
+					} else if (cmd->flags & COM_CLIENT && !(cmd->flags & COM_LUACOM))
+					{
+						CONS_Printf("\tOrigin: Client""\x82"" (Check Banpyura's \"README.md\" file for more information)\n");
+					} else {
+						CONS_Printf("\tOrigin: Addon""\x82"" (Refer to the addon page for more information)\n");
+					}
+				}
 				return;
 			}
-
-			CONS_Printf("No variable or command named %s", help);
-			CONS_Printf("\x82""\nCheck wiki.srb2.org for more or try typing help without arguments\n");
 		}
+
+		CONS_Printf("No command or variable named %s exists.", help);
+		CONS_Printf("\x82""\nCheck wiki.srb2.org for more or try typing help without arguments. For info on flags, do \"help -f\".\n");
 		return;
 	}
 	else
 	{
-		// variables
-		CONS_Printf("\x82""Variables:\n");
-		for (cvar = consvar_vars; cvar; cvar = cvar->next)
+		// logic count thing was moved to COM_CONSLogicC_f
+
+		// origin index (same order as helpheaders)
+		UINT8 oi = 0;
+
+		// only eval this once
+		isitallfalse = (!parmv && !parmc && !parma);
+
+		// slightly less ternary spam
+		const char* helpheaders[] = {"Vanilla:", "Client:", "Addon:"};
+
+		while (oi <= 2)
 		{
-			if (cvar->flags & CV_NOSHOWHELP)
-				continue;
-			CONS_Printf("%s ", cvar->name);
-			i++;
+			if (!isitallfalse) {
+				if (!parmv && oi == 0)
+					oi++;
+				if (!parmc && oi == 1)
+					oi++;
+				if (!parma && oi == 2)
+					break;
+			}
+
+			foundflag = false;
+			if (!iscomloop) {
+				CONS_Printf("\x83%s\n\t""\x82Variables: \x80", helpheaders[oi]);
+				for (cvar = consvar_vars; cvar; cvar = cvar->next)
+				{
+					if (cvar->flags & CV_NOSHOWHELP)
+						continue;
+					
+					if (oi == 0 && cvar->flags & (CV_CLIENT | CV_LUAVAR))
+						continue;
+					
+					if (oi == 1 && ((cvar->flags & CV_LUAVAR) || !(cvar->flags & CV_CLIENT)))
+						continue;
+
+					if (oi == 2 && !(cvar->flags & CV_LUAVAR))
+						continue;
+					
+					CONS_Printf("%s ", cvar->name);
+					if (oi == 2)
+						foundflag = true;
+				}
+			} else {
+				CONS_Printf("\t\x82""Commands: ""\x80");
+				for (cmd = com_commands; cmd; cmd = cmd->next)
+				{
+					
+					if (oi == 0 && cmd->flags & (COM_CLIENT | COM_LUACOM))
+						continue;
+					
+					if (oi == 1 && ((cmd->flags & COM_LUACOM) || !(cmd->flags & COM_CLIENT)))
+						continue;
+
+					if (oi == 2 && !(cmd->flags & COM_LUACOM))
+						continue;
+					
+					CONS_Printf("%s ", cmd->name);
+					if (oi == 2)
+						foundflag = true;
+				}
+			}
+
+			if (oi == 2 && !foundflag)
+				CONS_Printf("(no %s have been created by addons)", (iscomloop ? "commands" : "variables"));
+
+			CONS_Printf("\n"); // new line right after
+			
+			// only increment if this is done
+			if (iscomloop) {
+				oi++;
+			}	
+
+			// gcc would optimize !bool probably so this is unneded but like
+			// just in case... since this *SHOULD* be a singular CPU instruction in theorem
+			iscomloop ^= 1;
 		}
 
-		// commands
-		CONS_Printf("\x82""\nCommands:\n");
-		for (cmd = com_commands; cmd; cmd = cmd->next)
-		{
-			CONS_Printf("%s ",cmd->name);
-			i++;
-		}
+		CONS_Printf("\x82""\nCheck wiki.srb2.org for more or type help <command or variable>. For information about flags, do \"help -f\".\n");
 
-		CONS_Printf("\x82""\nCheck wiki.srb2.org for more or type help <command or variable>\n");
-
-		CONS_Debug(DBG_GAMELOGIC, "\x82Total : %d\n", i);
 	}
+}
+
+static void COM_CONSLogicC_f(void)
+{
+	xcommand_t *cmd;
+	consvar_t *cvar;
+	INT32 i = 0;
+
+	// (im just lazy to switch it off from CONS_Debug)
+	if (!(cv_debug & DBG_GAMELOGIC))
+	{
+		CONS_Printf("DEVMODE must be enabled and set to gamelogic to use this.\n");
+		return;
+	}
+
+	for (cvar = consvar_vars; cvar; cvar = cvar->next)
+	{
+		i++;
+	}
+
+	for (cmd = com_commands; cmd; cmd = cmd->next)
+	{
+		i++;
+	}
+
+	CONS_Debug(DBG_GAMELOGIC, "\x82Total : %d\n", i);
 }
 
 static void COM_Find_f(void)
@@ -2494,6 +2557,142 @@ static boolean CV_FilterVarByVersion(consvar_t *v, const char *valstr)
 	return true;
 }
 
+// Print out the info of a cvar.
+static void CV_Info(consvar_t *v)
+{
+	boolean floatmode = false;
+	INT32 i = 0;
+
+	CONS_Printf("\x82""Variable %s:\n", v->name);
+	if (!(cv_cvarinformation.value == 2 || cv_cvarinformation.value == 3))
+	{
+		CONS_Printf(M_GetText("  flags: "));
+
+		// This sucks. But I do not want to overcomplicate either.
+		if (v->flags & CV_SAVE)
+			CONS_Printf("CV_SAVE ");
+
+		if (v->flags & CV_CALL)
+			CONS_Printf("CV_CALL ");
+
+		if (v->flags & CV_NETVAR)
+			CONS_Printf("CV_NETVAR ");
+
+		if (v->flags & CV_NOINIT)
+			CONS_Printf("CV_NOINIT ");
+
+		if (v->flags & CV_FLOAT)
+		{
+			CONS_Printf("CV_FLOAT ");
+			floatmode = true;
+		}
+
+		if (v->flags & CV_NOTINNET)
+			CONS_Printf("CV_NOTINNET ");
+
+		if (v->flags & CV_MODIFIED)
+			CONS_Printf("CV_MODIFIED ");
+
+		if (v->flags & CV_SHOWMODIF)
+			CONS_Printf("CV_SHOWMODIF ");
+
+		if (v->flags & CV_SHOWMODIFONETIME)
+			CONS_Printf("CV_SHOWMODIFONETIME ");
+
+		if (v->flags & CV_NOSHOWHELP)
+			CONS_Printf("CV_NOSHOWHELP ");
+
+		if (v->flags & CV_CHEAT)
+			CONS_Printf("CV_CHEAT ");
+
+		if (v->flags & CV_ALLOWLUA)
+			CONS_Printf("CV_ALLOWLUA ");
+
+		if (v->flags & CV_LUAVAR)
+			CONS_Printf("CV_LUAVAR ");
+
+		if (v->flags & CV_CLIENT)
+			CONS_Printf("CV_CLIENT");
+
+		CONS_Printf("\n");
+	}
+	if (!(cv_cvarinformation.value == 1 || cv_cvarinformation.value == 3))
+	{
+		if (!(v->flags & (CV_LUAVAR | CV_CLIENT)))
+		{
+			CONS_Printf("\tOrigin: Vanilla""\x82"" (Check wiki.srb2.org for more information)\n");
+		} else if (v->flags & CV_LUAVAR)
+		{
+			CONS_Printf("\tOrigin: Addon""\x82"" (Refer to the addon for more information)\n");
+		} else if (v->flags & CV_CLIENT && !(v->flags & CV_LUAVAR))
+		{
+			CONS_Printf("\tOrigin: Client""\x82"" (Check Banpyura's README for more information)\n");
+		}
+	}
+			
+	if (v->PossibleValue)
+	{
+		CONS_Printf("\tPossible values:\n");
+		if (v->PossibleValue == CV_YesNo)
+			CONS_Printf("\t  Yes or No (On or Off, True or False, 1 or 0)\n");
+		else if (v->PossibleValue == CV_OnOff)
+			CONS_Printf("\t  On or Off (Yes or No, True or False, 1 or 0)\n");
+		else if (v->PossibleValue == CV_TrueFalse)
+			CONS_Printf("\t  True or False (On or Off, Yes or No, 1 or 0)\n");
+		else if (v->PossibleValue == Color_cons_t)
+		{
+			for (i = 1; i < numskincolors; ++i)
+			{
+				if (skincolors[i].accessible)
+				{
+					CONS_Printf("\t  %-2d : %s\n", i, skincolors[i].name);
+				}
+			}
+		}
+		else
+		{
+#define MINVAL 0
+#define MAXVAL 1
+		if (!stricmp(v->PossibleValue[MINVAL].strvalue, "MIN"))
+		{
+			if (floatmode)
+			{
+				float fu = FIXED_TO_FLOAT(v->PossibleValue[MINVAL].value);
+				float ck = FIXED_TO_FLOAT(v->PossibleValue[MAXVAL].value);
+				CONS_Printf("\t  range from %ld%s to %ld%s\n",
+					(long)fu, M_Ftrim(fu),
+					(long)ck, M_Ftrim(ck));
+			}
+			else
+				CONS_Printf("\t  range from %d to %d\n", v->PossibleValue[MINVAL].value,
+					v->PossibleValue[MAXVAL].value);
+			i = MAXVAL+1;
+		}
+#undef MINVAL
+#undef MAXVAL
+
+		while (v->PossibleValue[i].strvalue)
+		{
+			if (floatmode)
+			{
+				CONS_Printf("\t  %-2f : %s\n", FIXED_TO_FLOAT(v->PossibleValue[i].value),
+					v->PossibleValue[i].strvalue);
+			} else
+			{
+				CONS_Printf("\t  %-2d : %s\n", v->PossibleValue[i].value,
+					v->PossibleValue[i].strvalue);
+			}
+			i++;
+		}
+		}
+	}
+
+	CONS_Printf("\nValue is \"%s\" default is \"%s\"\n", v->string, v->defaultvalue);
+
+	if (v->revert.v.string != NULL && strcmp(v->revert.v.string, v->string) != 0)
+		CONS_Printf(" Value before netgame: %s\n", v->revert.v.string);
+}
+
 /** Displays or changes a variable from the console.
   * Since the user is presumed to have been directly responsible
   * for this change, the variable is marked as changed this game.
@@ -2520,7 +2719,7 @@ static boolean CV_Command(void)
 	// perform a variable print or set
 	if (COM_Argc() == 1)
 	{
-		CONS_Printf(M_GetText("\"%s\" is \"%s\" default is \"%s\"\n"), v->name, v->string, v->defaultvalue);
+		CV_Info(v);
 		return true;
 	}
 

--- a/src/command.h
+++ b/src/command.h
@@ -33,6 +33,8 @@ typedef enum
 	// COM_AddCommand: without this flag, the command
 	// CANNOT be run from Lua.
 	COM_LUA         = 8,
+	COM_LUACOM		= 16,
+	COM_CLIENT		= 32,
 } com_flags_t;
 
 typedef void (*com_func_t)(void);
@@ -125,6 +127,8 @@ typedef enum
                    // used on menus
 	CV_CHEAT = 2048, // Don't let this be used in multiplayer unless cheats are on.
 	CV_ALLOWLUA = 4096,/* Let this be called from Lua */
+	CV_CLIENT = 8192,
+	CV_LUAVAR = 16384,
 } cvflags_t;
 
 typedef struct CV_PossibleValue_s

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -322,18 +322,18 @@ static CV_PossibleValue_t chatx_cons_t[] = {{-BASEVIDWIDTH/2, "MIN"}, {BASEVIDWI
 static CV_PossibleValue_t chaty_cons_t[] = {{-BASEVIDHEIGHT/2, "MIN"}, {BASEVIDHEIGHT, "MAX"}, {0, NULL}};
 static CV_PossibleValue_t chatsnapx_cons_t[] = {{V_SNAPTOLEFT, "Left"}, {V_SNAPTORIGHT, "Right"}, {0, NULL}};
 static CV_PossibleValue_t chatsnapy_cons_t[] = {{V_SNAPTOTOP, "Top"}, {V_SNAPTOBOTTOM, "Bottom"}, {0, NULL}};
-consvar_t cv_chatx = CVAR_INIT ("chatx", "13", CV_SAVE, chatx_cons_t, NULL);
-consvar_t cv_chaty = CVAR_INIT ("chaty", "169", CV_SAVE, chaty_cons_t, NULL);
-consvar_t cv_chatsnapx = CVAR_INIT ("chatsnapx", "Left", CV_SAVE, chatsnapx_cons_t, NULL);
-consvar_t cv_chatsnapy = CVAR_INIT ("chatsnapy", "Bottom", CV_SAVE, chatsnapy_cons_t, NULL);
+consvar_t cv_chatx = CVAR_INIT ("chatx", "13", CV_SAVE|CV_CLIENT, chatx_cons_t, NULL);
+consvar_t cv_chaty = CVAR_INIT ("chaty", "169", CV_SAVE|CV_CLIENT, chaty_cons_t, NULL);
+consvar_t cv_chatsnapx = CVAR_INIT ("chatsnapx", "Left", CV_SAVE|CV_CLIENT, chatsnapx_cons_t, NULL);
+consvar_t cv_chatsnapy = CVAR_INIT ("chatsnapy", "Bottom", CV_SAVE|CV_CLIENT, chatsnapy_cons_t, NULL);
 
 // MORE chat stuff!!! YUM!!!!
-consvar_t cv_chat_showlimit = CVAR_INIT ("chat_showlimit", "On", CV_SAVE, CV_OnOff, NULL);
-consvar_t cv_chat_clearonexit = CVAR_INIT ("chat_clearonexit", "On", CV_SAVE, CV_OnOff, NULL);
+consvar_t cv_chat_showlimit = CVAR_INIT ("chat_showlimit", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
+consvar_t cv_chat_clearonexit = CVAR_INIT ("chat_clearonexit", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 // romoney5: make the chat cursor a pipe like every other text box made after the 2000s
 static CV_PossibleValue_t chatcursor_cons_t[] = {{1, "_"}, {2, "|"}, {0, NULL}};
-consvar_t cv_chatcursor = CVAR_INIT ("chatcursor", "|", CV_SAVE, chatcursor_cons_t, NULL);
+consvar_t cv_chatcursor = CVAR_INIT ("chatcursor", "|", CV_SAVE|CV_CLIENT, chatcursor_cons_t, NULL);
 
 // Pause game upon window losing focus
 consvar_t cv_pauseifunfocused = CVAR_INIT ("pauseifunfocused", "Yes", CV_SAVE, CV_YesNo, NULL);
@@ -342,8 +342,8 @@ consvar_t cv_instantretry = CVAR_INIT ("instantretry", "No", CV_SAVE, CV_YesNo, 
 
 consvar_t cv_crosshair = CVAR_INIT ("crosshair", "Cross", CV_SAVE, crosshair_cons_t, NULL);
 consvar_t cv_crosshair2 = CVAR_INIT ("crosshair2", "Cross", CV_SAVE, crosshair_cons_t, NULL);
-consvar_t cv_crosshair_invert = CVAR_INIT ("crosshair_invert", "No", CV_SAVE, CV_YesNo, NULL);
-consvar_t cv_crosshair2_invert = CVAR_INIT ("crosshair2_invert", "No", CV_SAVE, CV_YesNo, NULL);
+consvar_t cv_crosshair_invert = CVAR_INIT ("crosshair_invert", "No", CV_SAVE|CV_CLIENT, CV_YesNo, NULL);
+consvar_t cv_crosshair2_invert = CVAR_INIT ("crosshair2_invert", "No", CV_SAVE|CV_CLIENT, CV_YesNo, NULL);
 consvar_t cv_invertmouse = CVAR_INIT ("invertmouse", "Off", CV_SAVE, CV_OnOff, NULL);
 consvar_t cv_alwaysfreelook = CVAR_INIT ("alwaysmlook", "On", CV_SAVE, CV_OnOff, NULL);
 consvar_t cv_invertmouse2 = CVAR_INIT ("invertmouse2", "Off", CV_SAVE, CV_OnOff, NULL);
@@ -444,7 +444,7 @@ consvar_t cv_deadzone2 = CVAR_INIT ("joy_deadzone2", "0.125", CV_FLOAT|CV_SAVE, 
 consvar_t cv_digitaldeadzone2 = CVAR_INIT ("joy_digdeadzone2", "0.25", CV_FLOAT|CV_SAVE, zerotoone_cons_t, NULL);
 
 // disable wipes entirely
-consvar_t cv_wipes = CVAR_INIT ("wipes", "On", CV_SAVE, CV_OnOff, NULL);
+consvar_t cv_wipes = CVAR_INIT ("wipes", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 player_t *seenplayer; // player we're aiming at right now
 

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -5753,7 +5753,7 @@ static CV_PossibleValue_t glpalettedepth_cons_t[] = {{16, "16 bits"}, {24, "24 b
 
 consvar_t cv_glpaletterendering = CVAR_INIT ("gr_paletterendering", "On", CV_SAVE|CV_CALL, CV_OnOff, CV_glpaletterendering_OnChange);
 consvar_t cv_glpalettedepth = CVAR_INIT ("gr_palettedepth", "16 bits", CV_SAVE|CV_CALL, glpalettedepth_cons_t, CV_glpalettedepth_OnChange);
-consvar_t cv_gllightdither = CVAR_INIT ("gr_lightdithering", "Off", CV_SAVE|CV_CALL, CV_OnOff, CV_gllightdithering_OnChange);
+consvar_t cv_gllightdither = CVAR_INIT ("gr_lightdithering", "Off", CV_SAVE|CV_CALL|CV_CLIENT, CV_OnOff, CV_gllightdithering_OnChange);
 
 #define ONLY_IF_GL_LOADED if (vid.glstate != VID_GL_LIBRARY_LOADED) return;
 consvar_t cv_glwireframe = CVAR_INIT ("gr_wireframe", "Off", 0, CV_OnOff, NULL);

--- a/src/lua_consolelib.c
+++ b/src/lua_consolelib.c
@@ -548,7 +548,7 @@ static int lib_cvRegisterVar(lua_State *L)
 		return luaL_error(L, M_GetText("Variable %s has CV_CALL without any callbacks"), cvar->name);
 	}
 
-	cvar->flags |= CV_ALLOWLUA;
+	cvar->flags |= CV_ALLOWLUA|CV_LUAVAR;
 	// actually time to register it to the console now! Finally!
 	cvar->flags |= CV_MODIFIED;
 	CV_RegisterVar(cvar);

--- a/src/m_anigif.c
+++ b/src/m_anigif.c
@@ -47,8 +47,8 @@ consvar_t cv_gif_optimize = CVAR_INIT ("gif_optimize", "On", CV_SAVE, CV_OnOff, 
 consvar_t cv_gif_downscale =  CVAR_INIT ("gif_downscale", "On", CV_SAVE, CV_OnOff, NULL);
 consvar_t cv_gif_dynamicdelay = CVAR_INIT ("gif_dynamicdelay", "On", CV_SAVE, gif_dynamicdelay_cons_t, NULL);
 consvar_t cv_gif_localcolortable =  CVAR_INIT ("gif_localcolortable", "On", CV_SAVE, CV_OnOff, NULL);
-consvar_t cv_gif_maxsize =  CVAR_INIT ("gif_maxsize", "10", CV_SAVE, gif_maxsize_cons_t, NULL);
-consvar_t cv_gif_rolling =  CVAR_INIT ("gif_rolling", "Off", CV_SAVE, CV_OnOff, NULL);
+consvar_t cv_gif_maxsize =  CVAR_INIT ("gif_maxsize", "10", CV_SAVE|CV_CLIENT, gif_maxsize_cons_t, NULL);
+consvar_t cv_gif_rolling =  CVAR_INIT ("gif_rolling", "Off", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 #ifdef HAVE_ANIGIF
 static boolean gif_optimize = false; // So nobody can do something dumb

--- a/src/netcode/d_clisrv.c
+++ b/src/netcode/d_clisrv.c
@@ -127,8 +127,8 @@ consvar_t cv_idletime = CVAR_INIT ("idletime", "3", CV_SAVE|CV_NETVAR, CV_Unsign
 consvar_t cv_httpsource = CVAR_INIT ("http_source", "", CV_SAVE, NULL, NULL);
 
 static CV_PossibleValue_t mindelay_cons_t[] = {{0, "MIN"}, {30, "MAX"}, {0, NULL}};
-consvar_t cv_mindelay = CVAR_INIT ("mindelay", "0", CV_SAVE, mindelay_cons_t, NULL);
-consvar_t cv_gentlemens = CVAR_INIT ("gentlemensdelay", "Off", CV_SAVE, CV_OnOff, NULL); // this should be a netvar Zzz...
+consvar_t cv_mindelay = CVAR_INIT ("mindelay", "0", CV_SAVE|CV_CLIENT, mindelay_cons_t, NULL);
+consvar_t cv_gentlemens = CVAR_INIT ("gentlemensdelay", "Off", CV_SAVE|CV_CLIENT, CV_OnOff, NULL); // this should be a netvar Zzz...
 
 void ResetNode(INT32 node)
 {

--- a/src/netcode/d_netcmd.c
+++ b/src/netcode/d_netcmd.c
@@ -405,6 +405,9 @@ consvar_t cv_freedemocamera = CVAR_INIT("freedemocamera", "Off", CV_SAVE, CV_OnO
 // NOTE: this should be in hw_main.c, but we can't put it there as it breaks dedicated build
 consvar_t cv_glallowshaders = CVAR_INIT ("gr_allowcustomshaders", "On", CV_NETVAR, CV_OnOff, NULL);
 
+static CV_PossibleValue_t cvarinfo_const_t[] = {{0, "Show All"}, {1, "Hide Origin"}, {2, "Hide Flags"}, {3, "Only Show Values"}, {0, NULL}};
+consvar_t cv_cvarinformation = CVAR_INIT ("cvarinfo", "Show All", CV_SAVE|CV_CLIENT, cvarinfo_const_t, NULL);
+
 char timedemo_name[256];
 boolean timedemo_csv;
 char timedemo_csv_id[256];
@@ -512,7 +515,7 @@ void D_RegisterServerCommands(void)
 
 	COM_AddCommand("addfolder", Command_Addfolder, COM_LUA);
 	COM_AddCommand("addfile", Command_Addfile, COM_LUA);
-	COM_AddCommand("addfilelocal", Command_Addfilelocal, COM_LUA);
+	COM_AddCommand("addfilelocal", Command_Addfilelocal, COM_LUA|COM_CLIENT);
 	COM_AddCommand("listwad", Command_ListWADS_f, COM_LUA);
 
 	COM_AddCommand("runsoc", Command_RunSOC, COM_LUA);
@@ -638,6 +641,8 @@ void D_RegisterServerCommands(void)
 	CV_RegisterVar(&cv_pingtimeout);
 	CV_RegisterVar(&cv_showping);
 
+	CV_RegisterVar(&cv_cvarinformation);
+
 	CV_RegisterVar(&cv_allowseenames);
 
 	// Other filesrch.c consvars are defined in D_RegisterClientCommands
@@ -709,7 +714,7 @@ void D_RegisterClientCommands(void)
 	COM_AddCommand("stopmovie", Command_StopMovie_f, COM_LUA);
 
 	// romoney5
-	COM_AddCommand("saveaddons", Command_SaveAddons_f, 0);
+	COM_AddCommand("saveaddons", Command_SaveAddons_f, COM_CLIENT);
 
 	CV_RegisterVar(&cv_screenshot_option);
 	CV_RegisterVar(&cv_screenshot_folder);

--- a/src/netcode/d_netcmd.h
+++ b/src/netcode/d_netcmd.h
@@ -116,6 +116,8 @@ extern consvar_t cv_perfstats;
 extern consvar_t cv_ps_samplesize;
 extern consvar_t cv_ps_descriptor;
 
+extern consvar_t cv_cvarinformation;
+
 extern char timedemo_name[256];
 extern boolean timedemo_csv;
 extern char timedemo_csv_id[256];

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9838,8 +9838,8 @@ consvar_t cv_cam_speed = CVAR_INIT ("cam_speed", "0.3", CV_FLOAT|CV_SAVE|CV_ALLO
 consvar_t cv_cam_rotate = CVAR_INIT ("cam_rotate", "0", CV_CALL|CV_NOINIT|CV_ALLOWLUA, CV_CamRotate, CV_CamRotate_OnChange);
 consvar_t cv_cam_rotspeed = CVAR_INIT ("cam_rotspeed", "10", CV_SAVE|CV_ALLOWLUA, rotation_cons_t, NULL);
 consvar_t cv_cam_turnmultiplier = CVAR_INIT ("cam_turnmultiplier", "0.75", CV_FLOAT|CV_SAVE|CV_ALLOWLUA, multiplier_cons_t, NULL);
-consvar_t cv_cam_gamepadxsensitivity = CVAR_INIT ("cam_gamepadxsensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA, sensitivity_cons_t, NULL);
-consvar_t cv_cam_gamepadysensitivity = CVAR_INIT ("cam_gamepadysensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA, sensitivity_cons_t, NULL);
+consvar_t cv_cam_gamepadxsensitivity = CVAR_INIT ("cam_gamepadxsensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA|CV_CLIENT, sensitivity_cons_t, NULL);
+consvar_t cv_cam_gamepadysensitivity = CVAR_INIT ("cam_gamepadysensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA|CV_CLIENT, sensitivity_cons_t, NULL);
 consvar_t cv_cam_orbit = CVAR_INIT ("cam_orbit", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_cam_adjust = CVAR_INIT ("cam_adjust", "On", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_cam2_dist = CVAR_INIT ("cam2_curdist", "160", CV_FLOAT|CV_ALLOWLUA, campos_cons_t, NULL);
@@ -9849,20 +9849,20 @@ consvar_t cv_cam2_speed = CVAR_INIT ("cam2_speed", "0.3", CV_FLOAT|CV_SAVE|CV_AL
 consvar_t cv_cam2_rotate = CVAR_INIT ("cam2_rotate", "0", CV_CALL|CV_NOINIT|CV_ALLOWLUA, CV_CamRotate, CV_CamRotate2_OnChange);
 consvar_t cv_cam2_rotspeed = CVAR_INIT ("cam2_rotspeed", "10", CV_SAVE|CV_ALLOWLUA, rotation_cons_t, NULL);
 consvar_t cv_cam2_turnmultiplier = CVAR_INIT ("cam2_turnmultiplier", "0.75", CV_FLOAT|CV_SAVE|CV_ALLOWLUA, multiplier_cons_t, NULL);
-consvar_t cv_cam2_gamepadxsensitivity = CVAR_INIT ("cam2_gamepadxsensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA, sensitivity_cons_t, NULL);
-consvar_t cv_cam2_gamepadysensitivity = CVAR_INIT ("cam2_gamepadysensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA, sensitivity_cons_t, NULL);
+consvar_t cv_cam2_gamepadxsensitivity = CVAR_INIT ("cam2_gamepadxsensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA|CV_CLIENT, sensitivity_cons_t, NULL);
+consvar_t cv_cam2_gamepadysensitivity = CVAR_INIT ("cam2_gamepadysensitivity", "1", CV_FLOAT|CV_SAVE|CV_ALLOWLUA|CV_CLIENT, sensitivity_cons_t, NULL);
 consvar_t cv_cam2_orbit = CVAR_INIT ("cam2_orbit", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_cam2_adjust = CVAR_INIT ("cam2_adjust", "On", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
 
 // romoney5: noclip camera
 static CV_PossibleValue_t clipping_cons_t[] = { {0, "Off"}, {1, "Vanilla"}, {2, "Exact"}, {0, NULL} };
 
-consvar_t cv_cam_clipping = CVAR_INIT ("cam_clipping", "Vanilla", CV_SAVE|CV_ALLOWLUA, clipping_cons_t, NULL);
-consvar_t cv_cam2_clipping = CVAR_INIT ("cam2_clipping", "Vanilla", CV_SAVE|CV_ALLOWLUA, clipping_cons_t, NULL);
+consvar_t cv_cam_clipping = CVAR_INIT ("cam_clipping", "Vanilla", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, clipping_cons_t, NULL);
+consvar_t cv_cam2_clipping = CVAR_INIT ("cam2_clipping", "Vanilla", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, clipping_cons_t, NULL);
 
 // romoney5: exact camera aiming
-consvar_t cv_cam_exact = CVAR_INIT ("cam_exact", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
-consvar_t cv_cam2_exact = CVAR_INIT ("cam2_exact", "Off", CV_SAVE|CV_ALLOWLUA, CV_OnOff, NULL);
+consvar_t cv_cam_exact = CVAR_INIT ("cam_exact", "Off", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, CV_OnOff, NULL);
+consvar_t cv_cam2_exact = CVAR_INIT ("cam2_exact", "Off", CV_SAVE|CV_ALLOWLUA|CV_CLIENT, CV_OnOff, NULL);
 
 // [standard vs simple][p1 or p2]
 consvar_t cv_cam_savedist[2][2] = {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -156,7 +156,7 @@ void SendWeaponPref2(void);
 consvar_t cv_tailspickup = CVAR_INIT ("tailspickup", "On", CV_NETVAR|CV_ALLOWLUA, CV_OnOff, NULL);
 consvar_t cv_chasecam = CVAR_INIT ("chasecam", "On", CV_CALL, CV_OnOff, ChaseCam_OnChange);
 consvar_t cv_chasecam2 = CVAR_INIT ("chasecam2", "On", CV_CALL, CV_OnOff, ChaseCam2_OnChange);
-consvar_t cv_menubgcolor = CVAR_INIT ("menubgcolor", "Blue", CV_SAVE, menubg_cons_t, NULL);
+consvar_t cv_menubgcolor = CVAR_INIT ("menubgcolor", "Blue", CV_SAVE|CV_CLIENT, menubg_cons_t, NULL);
 consvar_t cv_flipcam = CVAR_INIT ("flipcam", "No", CV_SAVE|CV_CALL|CV_NOINIT, CV_YesNo, FlipCam_OnChange);
 consvar_t cv_flipcam2 = CVAR_INIT ("flipcam2", "No", CV_SAVE|CV_CALL|CV_NOINIT, CV_YesNo, FlipCam2_OnChange);
 
@@ -165,7 +165,7 @@ consvar_t cv_skybox = CVAR_INIT ("skybox", "On", CV_SAVE, CV_OnOff, NULL);
 consvar_t cv_allowmlook = CVAR_INIT ("allowmlook", "Yes", CV_NETVAR|CV_ALLOWLUA, CV_YesNo, NULL);
 consvar_t cv_showhud = CVAR_INIT ("showhud", "Yes", CV_CALL|CV_ALLOWLUA,  CV_YesNo, R_SetViewSize);
 consvar_t cv_translucenthud = CVAR_INIT ("translucenthud", "10", CV_SAVE, translucenthud_cons_t, NULL);
-consvar_t cv_moviemodeinfo = CVAR_INIT ("moviemodeinfo", "Yes", CV_ALLOWLUA,  CV_YesNo, NULL);
+consvar_t cv_moviemodeinfo = CVAR_INIT ("moviemodeinfo", "Yes", CV_ALLOWLUA|CV_CLIENT,  CV_YesNo, NULL);
 
 consvar_t cv_translucency = CVAR_INIT ("translucency", "On", CV_SAVE, CV_OnOff, NULL);
 consvar_t cv_drawdist = CVAR_INIT ("drawdist", "Infinite", CV_SAVE, drawdist_cons_t, NULL);
@@ -174,7 +174,7 @@ consvar_t cv_drawdist_precip = CVAR_INIT ("drawdist_precip", "1024", CV_SAVE, dr
 consvar_t cv_fov = CVAR_INIT ("fov", "90", CV_SAVE|CV_FLOAT|CV_CALL, fov_cons_t, Fov_OnChange);
 consvar_t cv_fovchange = CVAR_INIT ("fovchange", "Off", CV_SAVE, CV_OnOff, NULL);
 consvar_t cv_maxportals = CVAR_INIT ("maxportals", "2", CV_SAVE, maxportals_cons_t, NULL);
-consvar_t cv_secbright = CVAR_INIT("r_secbright", "0", CV_SAVE, secbright_cons_t, NULL);
+consvar_t cv_secbright = CVAR_INIT("r_secbright", "0", CV_SAVE|CV_CLIENT, secbright_cons_t, NULL);
 
 consvar_t cv_renderview = CVAR_INIT ("renderview", "On", 0, CV_OnOff, NULL);
 consvar_t cv_renderwalls = CVAR_INIT ("r_renderwalls", "On", 0, CV_OnOff, NULL);

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -187,7 +187,7 @@ consvar_t cv_homremoval = CVAR_INIT ("homremoval", "No", CV_SAVE, homremoval_con
 
 consvar_t cv_renderstats = CVAR_INIT ("renderstats", "Off", 0, CV_OnOff, NULL);
 
-consvar_t cv_flashes = CVAR_INIT ("flashes", "On", CV_SAVE, CV_OnOff, NULL);
+consvar_t cv_flashes = CVAR_INIT ("flashes", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 void SplitScreen_OnChange(void)
 {

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -83,7 +83,7 @@ static CV_PossibleValue_t constextsize_cons_t[] = {
 static void CV_constextsize_OnChange(void);
 consvar_t cv_constextsize = CVAR_INIT ("con_textsize", "Medium", CV_SAVE|CV_CALL, constextsize_cons_t, CV_constextsize_OnChange);
 
-consvar_t cv_menucaps = CVAR_INIT ("menucaps", "On", CV_SAVE, CV_OnOff, NULL);
+consvar_t cv_menucaps = CVAR_INIT ("menucaps", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 static CV_PossibleValue_t menucolor_cons_t[] = {
 	{0, "White"},
@@ -93,7 +93,7 @@ static CV_PossibleValue_t menucolor_cons_t[] = {
 	{V_PURPLEMAP, "Purple"}, {V_MAGENTAMAP, "Magenta"}, {V_ROSYMAP, "Rosy"},
 	{V_BROWNMAP, "Brown"}, {V_GRAYMAP, "Gray"}, {V_INVERTMAP, "Inverted"},
 	{0, NULL} };
-consvar_t cv_menucolor = CVAR_INIT("menucolor", "Yellow", CV_SAVE, menucolor_cons_t, NULL);
+consvar_t cv_menucolor = CVAR_INIT("menucolor", "Yellow", CV_SAVE|CV_CLIENT, menucolor_cons_t, NULL);
 
 // local copy of the palette for V_GetColor()
 RGBA_t *pLocalPalette = NULL;


### PR DESCRIPTION
hihi sorry for this being PR'd "a little" late

i saw the ping but was currently doing something else

- Help sorting. (Including seperating conslogiccount, though renamed to consoleloggicount)
- - COM_LUACOM, COM_CLIENT, CV_CLIENT, CV_LUAVAR.
- CV_Command *also* displays full info
- Marked client cvars and commands.
- Though still a sea of if-checks, still "all" flags are printed

if i missed any cvars [or commands urgh], kindly start directing nuclear warheads at my house!

(This also ports in the `cvarinfo` consvar as well, for transparency: "Show All", "Hide Origin", "Hide Flags", "Only Show Values". Effects both help and CV_Command since that was moved into a function (#26))