### PR TITLE
Add freeslots command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Icon credits goes to ClovesCloestarSRB2 and his addon [New Springs](https://mb.s
 - Doing merely `<cvar>` has the same effect as `help <cvar>`.
 - Console variable information is more in-depth.
 - - You can choose to hide certain sections via `cvarinfo` ("Show All" by default).
+- See the amount of freeslots using `freeslots`.
 
 **Most of these options can be found in the menu under Banpyura Options....**
 

--- a/src/deh_lua.c
+++ b/src/deh_lua.c
@@ -61,6 +61,8 @@ static inline int lib_freeslot(lua_State *L)
 				r++;
 			} else
 				CONS_Alert(CONS_WARNING, "Ran out of free SFX slots!\n");
+
+			freeslots_sfx++;
 		}
 		else if (fastcmp(type, "SPR"))
 		{
@@ -85,6 +87,8 @@ static inline int lib_freeslot(lua_State *L)
 			}
 			if (j > SPR_LASTFREESLOT)
 				CONS_Alert(CONS_WARNING, "Ran out of free sprite slots!\n");
+
+			freeslots_spr++;
 		}
 		else if (fastcmp(type, "S"))
 		{
@@ -100,6 +104,8 @@ static inline int lib_freeslot(lua_State *L)
 				}
 			if (i == NUMSTATEFREESLOTS)
 				CONS_Alert(CONS_WARNING, "Ran out of free State slots!\n");
+
+			freeslots_s++;
 		}
 		else if (fastcmp(type, "MT"))
 		{
@@ -115,6 +121,8 @@ static inline int lib_freeslot(lua_State *L)
 				}
 			if (i == NUMMOBJFREESLOTS)
 				CONS_Alert(CONS_WARNING, "Ran out of free MobjType slots!\n");
+
+			freeslots_mt++;
 		}
 		else if (fastcmp(type, "SKINCOLOR"))
 		{
@@ -131,6 +139,8 @@ static inline int lib_freeslot(lua_State *L)
 				}
 			if (i == NUMCOLORFREESLOTS)
 				CONS_Alert(CONS_WARNING, "Ran out of free skincolor slots!\n");
+
+			freeslots_skincolor++;
 		}
 		else if (fastcmp(type, "SPR2"))
 		{
@@ -152,6 +162,8 @@ static inline int lib_freeslot(lua_State *L)
 				} else
 					CONS_Alert(CONS_WARNING, "Ran out of free SPR2 slots!\n");
 			}
+
+			freeslots_spr2++;
 		}
 		else if (fastcmp(type, "TOL"))
 		{
@@ -173,6 +185,8 @@ static inline int lib_freeslot(lua_State *L)
 					r++;
 				}
 			}
+
+			freeslots_tol++;
 		}
 		Z_Free(s);
 		lua_remove(L, 1);

--- a/src/deh_soc.c
+++ b/src/deh_soc.c
@@ -444,7 +444,11 @@ void readfreeslots(MYFILE *f)
 			// TODO: Out-of-slots warnings/errors.
 			// TODO: Name too long (truncated) warnings.
 			if (fastcmp(type, "SFX"))
+			{
 				S_AddSoundFx(word, false, 0, false);
+
+				freeslots_sfx++;
+			}
 			else if (fastcmp(type, "SPR"))
 			{
 				if (strlen(word) > MAXSPRITENAME)
@@ -461,6 +465,8 @@ void readfreeslots(MYFILE *f)
 					LUA_UpdateSprName(word, i);
 					break;
 				}
+
+				freeslots_spr++;
 			}
 			else if (fastcmp(type, "S"))
 			{
@@ -470,6 +476,8 @@ void readfreeslots(MYFILE *f)
 						strcpy(FREE_STATES[i],word);
 						break;
 					}
+
+				freeslots_s++;
 			}
 			else if (fastcmp(type, "MT"))
 			{
@@ -479,6 +487,8 @@ void readfreeslots(MYFILE *f)
 						strcpy(FREE_MOBJS[i],word);
 						break;
 					}
+
+				freeslots_mt++;
 			}
 			else if (fastcmp(type, "SKINCOLOR"))
 			{
@@ -489,6 +499,8 @@ void readfreeslots(MYFILE *f)
 						M_AddMenuColor(numskincolors++);
 						break;
 					}
+
+				freeslots_skincolor++;
 			}
 			else if (fastcmp(type, "SPR2"))
 			{
@@ -506,6 +518,8 @@ void readfreeslots(MYFILE *f)
 					spr2names[free_spr2++][4] = 0;
 				} else
 					deh_warning("Ran out of free SPR2 slots!\n");
+
+				freeslots_spr2++;
 			}
 			else if (fastcmp(type, "TOL"))
 			{
@@ -526,6 +540,8 @@ void readfreeslots(MYFILE *f)
 					G_AddTOL(lastcustomtol, word);
 					lastcustomtol <<= 1;
 				}
+
+				freeslots_tol++;
 			}
 			else
 				deh_warning("Freeslots: unknown enum class '%s' for '%s_%s'", type, type, word);

--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -22,6 +22,14 @@ boolean titlechanged = false;
 boolean introchanged = false;
 boolean bootmapchanged = false;
 
+INT32 freeslots_sfx = 0;
+INT32 freeslots_spr = 0;
+INT32 freeslots_s = 0;
+INT32 freeslots_mt = 0;
+INT32 freeslots_skincolor = 0;
+INT32 freeslots_spr2 = 0;
+INT32 freeslots_tol = 0;
+
 static int dbg_line;
 static INT32 deh_num_warning = 0;
 

--- a/src/dehacked.h
+++ b/src/dehacked.h
@@ -41,6 +41,14 @@ extern boolean titlechanged;
 extern boolean introchanged;
 extern boolean bootmapchanged;
 
+extern INT32 freeslots_sfx;
+extern INT32 freeslots_spr;
+extern INT32 freeslots_s;
+extern INT32 freeslots_mt;
+extern INT32 freeslots_skincolor;
+extern INT32 freeslots_spr2;
+extern INT32 freeslots_tol;
+
 #define MAX_ACTION_RECURSION 30
 extern const char *luaactions[MAX_ACTION_RECURSION];
 extern UINT8 luaactionstack;

--- a/src/netcode/d_netcmd.c
+++ b/src/netcode/d_netcmd.c
@@ -124,6 +124,7 @@ static void Command_Stopdemo_f(void);
 static void Command_StartMovie_f(void);
 static void Command_StopMovie_f(void);
 static void Command_SaveAddons_f(void);
+static void Command_Freeslots_f(void);
 static void Command_Map_f(void);
 static void Command_ResetCamera_f(void);
 
@@ -715,6 +716,7 @@ void D_RegisterClientCommands(void)
 
 	// romoney5
 	COM_AddCommand("saveaddons", Command_SaveAddons_f, COM_CLIENT);
+	COM_AddCommand("freeslots", Command_Freeslots_f, COM_CLIENT);
 
 	CV_RegisterVar(&cv_screenshot_option);
 	CV_RegisterVar(&cv_screenshot_folder);
@@ -1762,6 +1764,27 @@ static void Command_SaveAddons_f(void)
 	fclose(file);
 
 	CONS_Printf("Saved addon list (%d addons) to %s\n", savedaddons, filename);
+}
+
+// romoney5: print the amount of freeslots from lua and soc
+// inspired by the freeslots lua command i made
+static void Command_Freeslots_f(void)
+{
+	const INT32 max_sfx = 1600;
+	const INT32 max_spr = 1024;
+	const INT32 max_s = 8192;
+	const INT32 max_mt = 1024;
+	const INT32 max_skincolor = 1024;
+	const INT32 max_spr2 = 955;
+	const INT32 max_tol = 32 + 1; // tols are uint32 flags, so 2^32 (and 1)
+
+	CONS_Printf("\x8cSounds: %s%d/%d\x80\n", (freeslots_sfx >= max_sfx ? "\x85" : "\x80"), freeslots_sfx, max_sfx);
+	CONS_Printf("\x82Sprites: %s%d/%d\x80\n", (freeslots_spr >= max_spr ? "\x85" : "\x80"), freeslots_spr, max_spr);
+	CONS_Printf("\x8aStates: %s%d/%d\x80\n", (freeslots_s >= max_s ? "\x85" : "\x80"), freeslots_s, max_s);
+	CONS_Printf("\x83Mobj types: %s%d/%d\x80\n", (freeslots_mt >= max_mt ? "\x85" : "\x80"), freeslots_mt, max_mt);
+	CONS_Printf("\x88Skincolors: %s%d/%d\x80\n", (freeslots_skincolor >= max_skincolor ? "\x85" : "\x80"), freeslots_skincolor, max_skincolor);
+	CONS_Printf("\x8bSprite2s: %s%d/%d\x80\n", (freeslots_spr2 >= max_spr2 ? "\x85" : "\x80"), freeslots_spr2, max_spr2);
+	CONS_Printf("\x8eType of levels: %s%d/%d\x80\n", (freeslots_tol >= max_tol ? "\x85" : "\x80"), freeslots_tol, max_tol);
 }
 
 INT32 mapchangepending = 0;


### PR DESCRIPTION
The game now tracks the current amount of loaded freeslots and prints them upon using the command.
<img width="358" height="162" alt="image" src="https://github.com/user-attachments/assets/56f790ec-7cd8-4b61-bbc6-884ca5a0db42" />
