### PR TITLE
Make level palettes toggleable

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1516,28 +1516,31 @@ static menuitem_t OP_DataOptionsMenu[] =
 
 static menuitem_t OP_BanpyuraOptionsMenu[] =
 {
-	{IT_HEADER, 				NULL, "Heads-Up Display", 			            NULL,		   0},
-	{IT_STRING | IT_CVAR,		NULL, "Screen Fades",       			   &cv_wipes,          6},
-	{IT_STRING | IT_CVAR,		NULL, "Screen Flashes",       			 &cv_flashes,          11},
-	{IT_STRING | IT_CVAR,		NULL, "Uppercase Menus",       			&cv_menucaps,          16},
-	{IT_STRING | IT_CVAR,		NULL, "Menu Text Color",       	       &cv_menucolor,          21},
-	{IT_STRING | IT_CVAR,		NULL, "Menu Background Color",       &cv_menubgcolor,          26},
+	{IT_HEADER, 				NULL, "Heads-Up Display", 			            NULL,	   0},
+	{IT_STRING | IT_CVAR,		NULL, "Screen Fades",       			&cv_wipes,          6},
+	{IT_STRING | IT_CVAR,		NULL, "Screen Flashes",       			&cv_flashes,        11},
+	{IT_STRING | IT_CVAR,		NULL, "Uppercase Menus",       			&cv_menucaps,       16},
+	{IT_STRING | IT_CVAR,		NULL, "Menu Text Color",       	       		&cv_menucolor,      21},
+	{IT_STRING | IT_CVAR,		NULL, "Menu Background Color",       		&cv_menubgcolor,    26},
 
 	{IT_HEADER, 				NULL, "Chat Tweaks", 			            	NULL,		   36},
-	{IT_STRING | IT_CVAR,		NULL, "Horizontal Snap",       	  	   &cv_chatsnapx,          42},
-	{IT_STRING | IT_CVAR,		NULL, "Vertical Snap",       	  	   &cv_chatsnapy,          47},
-	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Horizontal Position",      &cv_chatx,          52},
-	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Vertical Position",    	   &cv_chaty,          57},
-	{IT_STRING | IT_CVAR,		NULL, "Show Char. Limit",         &cv_chat_showlimit,          62},
-	{IT_STRING | IT_CVAR,		NULL, "Clear Input text on Exit",&cv_chat_clearonexit,         67},
-	{IT_STRING | IT_CVAR,		NULL, "Chat Cursor",                  &cv_chatcursor,          72},
+	{IT_STRING | IT_CVAR,		NULL, "Horizontal Snap",       	  	   	&cv_chatsnapx,      42},
+	{IT_STRING | IT_CVAR,		NULL, "Vertical Snap",       	  	   	&cv_chatsnapy,      47},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Horizontal Position",      		&cv_chatx,          52},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Vertical Position",    	        &cv_chaty,          57},
+	{IT_STRING | IT_CVAR,		NULL, "Show Char. Limit",         		&cv_chat_showlimit, 62},
+	{IT_STRING | IT_CVAR,		NULL, "Clear Input text on Exit",		&cv_chat_clearonexit,67},
+	{IT_STRING | IT_CVAR,		NULL, "Chat Cursor",                  		&cv_chatcursor,     72},
 
-	{IT_HEADER, 				NULL, "Network", 			            		NULL,		   82},
-	{IT_STRING | IT_CVAR,		NULL, "Minimum Delay",       		    &cv_mindelay,          88},
-	{IT_STRING | IT_CVAR,		NULL, "Gentlemen's Delay",       	  &cv_gentlemens,          93},
+	{IT_HEADER, 				NULL, "Network", 			            	NULL,		   82},
+	{IT_STRING | IT_CVAR,		NULL, "Minimum Delay",       		    	&cv_mindelay,       88},
+	{IT_STRING | IT_CVAR,		NULL, "Gentlemen's Delay",       	  	&cv_gentlemens,     93},
 
 	{IT_HEADER, 				NULL, "Rendering (OpenGL)", 			        NULL,		   103},
-	{IT_STRING|IT_CVAR,         NULL, "Light Dithering",     	   &cv_gllightdither,          109},
+	{IT_STRING|IT_CVAR,         NULL, "Light Dithering",     	   	   	&cv_gllightdither,  109},
+
+	{IT_HEADER,				NULL, "Rendering (Both)",				NULL,		   119},
+	{IT_STRING|IT_CVAR,	    NULL, "Use Level Palette If Available",				&cv_uselevelpalette,125},
 };
 
 static menuitem_t OP_P1BanpyuraOptionsMenu[] =

--- a/src/screen.c
+++ b/src/screen.c
@@ -214,6 +214,7 @@ void SCR_Startup(void)
 	CV_RegisterVar(&cv_ticrate);
 	CV_RegisterVar(&cv_constextsize);
 	CV_RegisterVar(&cv_menucaps);
+	CV_RegisterVar(&cv_uselevelpalette);
 	CV_RegisterVar(&cv_menucolor);
 
 	V_SetPalette(0);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -84,6 +84,7 @@ static void CV_constextsize_OnChange(void);
 consvar_t cv_constextsize = CVAR_INIT ("con_textsize", "Medium", CV_SAVE|CV_CALL, constextsize_cons_t, CV_constextsize_OnChange);
 
 consvar_t cv_menucaps = CVAR_INIT ("menucaps", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
+consvar_t cv_uselevelpalette = CVAR_INIT ("uselevelpalette", "On", CV_SAVE|CV_CLIENT|CV_CALL|CV_NOINIT, CV_OnOff, CV_palette_OnChange); // nikoberry: Pretty sure this is a necessary use of CV_NOINIT?
 
 static CV_PossibleValue_t menucolor_cons_t[] = {
 	{0, "White"},
@@ -409,7 +410,7 @@ const char *R_GetPalname(UINT16 num)
 
 const char *GetPalette(void)
 {
-	if (gamestate == GS_LEVEL)
+	if (gamestate == GS_LEVEL && cv_uselevelpalette.value)
 		return R_GetPalname(mapheaderinfo[gamemap-1]->palette);
 	return "PLAYPAL";
 }

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -34,6 +34,8 @@ cv_rhue, cv_yhue, cv_ghue, cv_chue, cv_bhue, cv_mhue,
 cv_rgamma, cv_ygamma, cv_ggamma, cv_cgamma, cv_bgamma, cv_mgamma,
 cv_rsaturation, cv_ysaturation, cv_gsaturation, cv_csaturation, cv_bsaturation, cv_msaturation;
 
+extern consvar_t cv_uselevelpalette;
+
 // Allocates buffer screens, call before R_Init.
 void V_Init(void);
 


### PR DESCRIPTION
For when a map palette is so good that the eyes cannot bear it.

also aligns BanpyuraOptionsMenu properly (well, in `nano` it looked properly aligned now, but looking at the diff here on github, it looks maligned... if that was a me issue, do tell and I'll revert it asap)

Unsure if I should merge the rendering sections and just specify "(OpenGL)" at light dithering. I digress.

Demo:

Used in Example: [The Addon of All Time](https://mb.srb2.org/addons/3-1-2024.6294/) (3-1-2024)
The palette here has more bluer yellows (if that makes any sense; if it does not, look to the lefthand side of the GIF).

<img width="400" height="225" alt="srb20521" src="https://github.com/user-attachments/assets/849d1bc4-dfaa-43e1-8ab9-4865d77bab88" />

More noticable, with a colormap ([PVPalette](https://mb.srb2.org/addons/pvpalette-pvpal-v3-3-pk3.1931/))
<img width="400" height="225" alt="srb20522" src="https://github.com/user-attachments/assets/131222b9-56eb-4f54-9482-8121f9cd831a" />

I'd also make one for colormaps, but I cannot seem to find where I'd be able to do so, and altering the behaviour of linedefs would feel WAY too excessive.

###### PS: The tiny HUD seen within the GIF is a part of my unfinished alteration of Banpyura, it's not a part of the changes here.