### PR TITLE
port the fix for the float-integer fiasco in cropped patches

### DIFF
--- a/src/hardware/hw_draw.c
+++ b/src/hardware/hw_draw.c
@@ -256,8 +256,8 @@ void HWR_DrawStretchyFixedPatch(patch_t *gpatch, fixed_t x, fixed_t y, fixed_t p
 	}
 
 	// positions of the cx, cy, are between 0 and vid.width/vid.height now, we need them to be between -1 and 1
-	cx = -1 + (cx / (vid.width/2));
-	cy = 1 - (cy / (vid.height/2));
+	cx = -1.0f + (cx / (vid.width / 2.0f));
+	cy = 1.0f - (cy / (vid.height / 2.0f));
 
 	// fwidth and fheight are similar
 	fwidth /= vid.width / 2;
@@ -474,8 +474,8 @@ void HWR_DrawCroppedPatch(patch_t *gpatch, fixed_t x, fixed_t y, fixed_t pscale,
 	}
 
 	// positions of the cx, cy, are between 0 and vid.width/vid.height now, we need them to be between -1 and 1
-	cx = -1 + (cx / (vid.width/2));
-	cy = 1 - (cy / (vid.height/2));
+	cx = -1.0f + (cx / (vid.width / 2.0f));
+	cy = 1.0f - (cy / (vid.height / 2.0f));
 
 	// fwidth and fheight are similar
 	fwidth /= vid.width / 2;


### PR DESCRIPTION
title, this is from next, see https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2635/

In a nutshell, there's a buttload of float to integer and back conversions being done because these INTs (1 and 2) are not being optimized to floats at compile-time, causing a significant FPS drop.

Just making them floats prevents the insane amount of conversions.

This likely causes a conflict with `next` if merged.

It should be noted that vanilla `next` only does the fix for *stretched* patches, rather than normal cropped too, as this issue is present in both of the functions.