### PR TITLE
Add CameraThinker hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Icon credits goes to ClovesCloestarSRB2 and his addon [New Springs](https://mb.s
 - Minimum input delay and Gentleman's delay (Ring Racers)
 - `cam_centertoggle` and `cam2_centertoggle` are not exclusive to the Automatic playstyle.
 
+### Lua
+
+- Added `CameraThinker` hook to alter the camera's behavior.
+- - `player` and `camera` are passed in as arguments. Return `true` to override vanilla camera movement.
+
 ### Miscellaneous
 
 - Improved GIF recording.

--- a/src/lua_hook.h
+++ b/src/lua_hook.h
@@ -73,6 +73,7 @@ automatically.
 	X (PlayerHeight),/* override player height */\
 	X (PlayerCanEnterSpinGaps),\
 	X (AddonLoaded),\
+	X (CameraThinker),/* P_MoveChaseCamera */\
 	X (KeyDown),\
 	X (KeyUp),\
 
@@ -151,6 +152,7 @@ int  LUA_HookPlayerMsg(int source, int target, int flags, char *msg);
 int  LUA_HookHurtMsg(player_t *, mobj_t *inflictor, mobj_t *source, UINT8 damagetype);
 int  LUA_HookMapThingSpawn(mobj_t *, mapthing_t *);
 int  LUA_HookFollowMobj(player_t *, mobj_t *);
+int  LUA_HookCameraThinker(player_t *, camera_t *);
 int  LUA_HookPlayerCanDamage(player_t *, mobj_t *);
 void LUA_HookPlayerQuit(player_t *, kickreason_t);
 int  LUA_HookTeamSwitch(player_t *, int newteam, boolean fromspectators, boolean tryingautobalance, boolean tryingscramble);

--- a/src/lua_hooklib.c
+++ b/src/lua_hooklib.c
@@ -1054,6 +1054,18 @@ int LUA_HookFollowMobj(player_t *player, mobj_t *mobj)
 	return hook.status;
 }
 
+int LUA_HookCameraThinker(player_t *player, camera_t *camera)
+{
+	Hook_State hook;
+	if (prepare_hook(&hook, false, HOOK(CameraThinker)))
+	{
+		LUA_PushUserdata(gL, player, META_PLAYER);
+		LUA_PushUserdata(gL, camera, META_CAMERA);
+		call_hooks(&hook, 1, res_true);
+	}
+	return hook.status;
+}
+
 int LUA_HookPlayerCanDamage(player_t *player, mobj_t *mobj)
 {
 	Hook_State hook;

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9976,6 +9976,9 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 
 	mo = player->mo;
 
+	if (LUA_HookCameraThinker(player, thiscam))
+		return true;
+
 	if (player->playerstate == PST_REBORN)
 	{
 		P_CalcChasePostImg(player, thiscam);

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -9976,10 +9976,7 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 
 	mo = player->mo;
 
-	if (LUA_HookCameraThinker(player, thiscam))
-		return true;
-
-	if (player->playerstate == PST_REBORN)
+	if (LUA_HookCameraThinker(player, thiscam) || player->playerstate == PST_REBORN)
 	{
 		P_CalcChasePostImg(player, thiscam);
 		return true;


### PR DESCRIPTION
This hook is designed to control camera movement locally (run right before P_MoveChaseCamera) without having to worry about other local hooks or HUD hooks that may not always get the timing right.
The player and camera are passed in as arguments to the hook.
Returning true in the hook disables vanilla camera movement entirely, skipping the rest of P_MoveChaseCamera.

Example code:
```lua
addHook("CameraThinker", function(player, camera)
	P_TeleportCameraMove(camera, 0, 0, 0)
	camera.momx, camera.momy, camera.momz = 0, 0, 0
	
	return true
end)
```