### PR TITLE
customizable chat translucency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Icon credits goes to ClovesCloestarSRB2 and his addon [New Springs](https://mb.s
 ### HUD/Menus
 
 - Toggle screen fades (`wipes`). Not effective in Marathon Run.
-- Lots of chat tweaks! Window positioning, snapping, copy-paste, selection, and more.
+- Lots of chat tweaks! Window positioning, snapping, copy-paste, selection, customizable opacity, and more.
 - Menu tweaks! background color, text case switching, selection color.
 - Extra camera options: Exact aiming, Clipping style, Gamepad Camera sensitivity
 - Addons menu has it's background translucent and their text on thin font.

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -322,12 +322,12 @@ static CV_PossibleValue_t chatx_cons_t[] = {{-BASEVIDWIDTH/2, "MIN"}, {BASEVIDWI
 static CV_PossibleValue_t chaty_cons_t[] = {{-BASEVIDHEIGHT/2, "MIN"}, {BASEVIDHEIGHT, "MAX"}, {0, NULL}};
 static CV_PossibleValue_t chatsnapx_cons_t[] = {{V_SNAPTOLEFT, "Left"}, {V_SNAPTORIGHT, "Right"}, {0, NULL}};
 static CV_PossibleValue_t chatsnapy_cons_t[] = {{V_SNAPTOTOP, "Top"}, {V_SNAPTOBOTTOM, "Bottom"}, {0, NULL}};
-static CV_PossibleValue_t chatlucency_cons_t[] = {{0, "MIN"}, {10, "MAX"}, {0, NULL}};
+static CV_PossibleValue_t chatopacity_cons_t[] = {{0, "MIN"}, {10, "MAX"}, {0, NULL}};
 consvar_t cv_chatx = CVAR_INIT ("chatx", "13", CV_SAVE|CV_CLIENT, chatx_cons_t, NULL);
 consvar_t cv_chaty = CVAR_INIT ("chaty", "169", CV_SAVE|CV_CLIENT, chaty_cons_t, NULL);
 consvar_t cv_chatsnapx = CVAR_INIT ("chatsnapx", "Left", CV_SAVE|CV_CLIENT, chatsnapx_cons_t, NULL);
 consvar_t cv_chatsnapy = CVAR_INIT ("chatsnapy", "Bottom", CV_SAVE|CV_CLIENT, chatsnapy_cons_t, NULL);
-consvar_t cv_chatlucency = CVAR_INIT ("chattranslucency", "5", CV_SAVE|CV_CLIENT, chatlucency_cons_t, NULL);
+consvar_t cv_chatopacity = CVAR_INIT ("chatopacity", "5", CV_SAVE|CV_CLIENT, chatopacity_cons_t, NULL);
 
 // MORE chat stuff!!! YUM!!!!
 consvar_t cv_chat_showlimit = CVAR_INIT ("chat_showlimit", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -322,10 +322,12 @@ static CV_PossibleValue_t chatx_cons_t[] = {{-BASEVIDWIDTH/2, "MIN"}, {BASEVIDWI
 static CV_PossibleValue_t chaty_cons_t[] = {{-BASEVIDHEIGHT/2, "MIN"}, {BASEVIDHEIGHT, "MAX"}, {0, NULL}};
 static CV_PossibleValue_t chatsnapx_cons_t[] = {{V_SNAPTOLEFT, "Left"}, {V_SNAPTORIGHT, "Right"}, {0, NULL}};
 static CV_PossibleValue_t chatsnapy_cons_t[] = {{V_SNAPTOTOP, "Top"}, {V_SNAPTOBOTTOM, "Bottom"}, {0, NULL}};
+static CV_PossibleValue_t chatlucency_cons_t[] = {{0, "MIN"}, {10, "MAX"}, {0, NULL}};
 consvar_t cv_chatx = CVAR_INIT ("chatx", "13", CV_SAVE|CV_CLIENT, chatx_cons_t, NULL);
 consvar_t cv_chaty = CVAR_INIT ("chaty", "169", CV_SAVE|CV_CLIENT, chaty_cons_t, NULL);
 consvar_t cv_chatsnapx = CVAR_INIT ("chatsnapx", "Left", CV_SAVE|CV_CLIENT, chatsnapx_cons_t, NULL);
 consvar_t cv_chatsnapy = CVAR_INIT ("chatsnapy", "Bottom", CV_SAVE|CV_CLIENT, chatsnapy_cons_t, NULL);
+consvar_t cv_chatlucency = CVAR_INIT ("chattranslucency", "5", CV_SAVE|CV_CLIENT, chatlucency_cons_t, NULL);
 
 // MORE chat stuff!!! YUM!!!!
 consvar_t cv_chat_showlimit = CVAR_INIT ("chat_showlimit", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -57,7 +57,7 @@ extern consvar_t cv_chatwidth, cv_chatnotifications, cv_chatheight, cv_chattime,
 	cv_chatbacktint, cv_chatspamprotection, cv_chatspamspeed, cv_chatspamburst, cv_compactscoreboard,
 	cv_chatcursor;
 //				 x         y         horiz snap    vert snap
-extern consvar_t cv_chatx, cv_chaty, cv_chatsnapx, cv_chatsnapy, cv_chat_showlimit, cv_chat_clearonexit;
+extern consvar_t cv_chatx, cv_chaty, cv_chatsnapx, cv_chatsnapy, cv_chat_showlimit, cv_chat_clearonexit, cv_chatlucency;
 extern consvar_t cv_crosshair, cv_crosshair2;
 extern consvar_t cv_crosshair_invert, cv_crosshair2_invert;
 extern consvar_t cv_invertmouse, cv_alwaysfreelook, cv_chasefreelook, cv_mousemove;

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -57,7 +57,7 @@ extern consvar_t cv_chatwidth, cv_chatnotifications, cv_chatheight, cv_chattime,
 	cv_chatbacktint, cv_chatspamprotection, cv_chatspamspeed, cv_chatspamburst, cv_compactscoreboard,
 	cv_chatcursor;
 //				 x         y         horiz snap    vert snap
-extern consvar_t cv_chatx, cv_chaty, cv_chatsnapx, cv_chatsnapy, cv_chat_showlimit, cv_chat_clearonexit, cv_chatlucency;
+extern consvar_t cv_chatx, cv_chaty, cv_chatsnapx, cv_chatsnapy, cv_chat_showlimit, cv_chat_clearonexit, cv_chatopacity;
 extern consvar_t cv_crosshair, cv_crosshair2;
 extern consvar_t cv_crosshair_invert, cv_crosshair2_invert;
 extern consvar_t cv_invertmouse, cv_alwaysfreelook, cv_chasefreelook, cv_mousemove;

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1529,7 +1529,7 @@ static void HU_drawMiniChat(void)
 				prev_linereturn = false;
 
 				if (cv_chatbacktint.value) // on request of wolfy
-					V_DrawFill(x + dx + 2, y+dy, charwidth, charheight, CHATLUCENCY|cv_menubgcolor.value|chatsnap);
+					V_DrawFill(x + dx + 2, y+dy, charwidth, charheight, CHATOPACITY|cv_menubgcolor.value|chatsnap);
 
 				V_DrawChatCharacter(x + dx + 2, y+dy, msg[j] |chatsnap|V_MONOSPACE|transflag, true, colormap);
 				dx += charwidth;
@@ -1593,7 +1593,7 @@ static void HU_drawChatLog(INT32 offset)
 	chat_bottomy = chat_topy + boxh*charheight;
 
 	if (cv_chatbacktint.value)
-		V_DrawFill(chatx, chat_topy, boxw, boxh*charheight +2, CHATLUCENCY|cv_menubgcolor.value|chatsnap); // log box
+		V_DrawFill(chatx, chat_topy, boxw, boxh*charheight +2, CHATOPACITY|cv_menubgcolor.value|chatsnap); // log box
 
 	for (i=0; i<chat_nummsg_log; i++) // iterate through our chatlog
 	{
@@ -1705,7 +1705,7 @@ static void HU_DrawChat(void)
 	}
 
 	if (cv_chatbacktint.value)
-		V_DrawFill(chatx, y-1, boxw, (typelines*charheight), CHATLUCENCY|cv_menubgcolor.value|chatsnap);
+		V_DrawFill(chatx, y-1, boxw, (typelines*charheight), CHATOPACITY|cv_menubgcolor.value|chatsnap);
 
 	for (i = 0; talk[i]; i++)
 	{
@@ -1823,14 +1823,14 @@ static void HU_DrawChat(void)
 			{
 				char name[MAXPLAYERNAME+1];
 				strlcpy(name, player_names[i], 7); // shorten name to 7 characters.
-				V_DrawFill(chatx+ boxw + 2, p_dispy- (6*count), 48, 6, CHATLUCENCY|cv_menubgcolor.value|chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
+				V_DrawFill(chatx+ boxw + 2, p_dispy- (6*count), 48, 6, CHATOPACITY|cv_menubgcolor.value|chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
 				V_DrawSmallString(chatx+ boxw + 4, p_dispy- (6*count), chatsnap|V_ALLOWLOWERCASE, va("\x82%d\x80 - %s", i, name));
 				count++;
 			}
 		}
 		if (count == 0) // no results.
 		{
-			V_DrawFill(chatx+boxw+2, p_dispy- (6*count), 48, 6, CHATLUCENCY|cv_menubgcolor.value|chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
+			V_DrawFill(chatx+boxw+2, p_dispy- (6*count), 48, 6, CHATOPACITY|cv_menubgcolor.value|chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
 			V_DrawSmallString(chatx+boxw+4, p_dispy- (6*count), chatsnap|V_ALLOWLOWERCASE, "NO RESULT.");
 		}
 	}

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1529,7 +1529,7 @@ static void HU_drawMiniChat(void)
 				prev_linereturn = false;
 
 				if (cv_chatbacktint.value) // on request of wolfy
-					V_DrawFillConsoleMap(x + dx + 2, y+dy, charwidth, charheight, 239|chatsnap);
+					V_DrawFill(x + dx + 2, y+dy, charwidth, charheight, CHATLUCENCY|cv_menubgcolor.value|chatsnap);
 
 				V_DrawChatCharacter(x + dx + 2, y+dy, msg[j] |chatsnap|V_MONOSPACE|transflag, true, colormap);
 				dx += charwidth;
@@ -1592,7 +1592,8 @@ static void HU_drawChatLog(INT32 offset)
 	chat_topy = y + chat_scroll*charheight;
 	chat_bottomy = chat_topy + boxh*charheight;
 
-	V_DrawFillConsoleMap(chatx, chat_topy, boxw, boxh*charheight +2, 239|chatsnap); // log box
+	if (cv_chatbacktint.value)
+		V_DrawFill(chatx, chat_topy, boxw, boxh*charheight +2, CHATLUCENCY|cv_menubgcolor.value|chatsnap); // log box
 
 	for (i=0; i<chat_nummsg_log; i++) // iterate through our chatlog
 	{
@@ -1703,7 +1704,8 @@ static void HU_DrawChat(void)
 		cflag = V_GRAYMAP; // set text in gray if chat is muted.
 	}
 
-	V_DrawFillConsoleMap(chatx, y-1, boxw, (typelines*charheight), 239 | chatsnap);
+	if (cv_chatbacktint.value)
+		V_DrawFill(chatx, y-1, boxw, (typelines*charheight), CHATLUCENCY|cv_menubgcolor.value|chatsnap);
 
 	for (i = 0; talk[i]; i++)
 	{
@@ -1821,14 +1823,14 @@ static void HU_DrawChat(void)
 			{
 				char name[MAXPLAYERNAME+1];
 				strlcpy(name, player_names[i], 7); // shorten name to 7 characters.
-				V_DrawFillConsoleMap(chatx+ boxw + 2, p_dispy- (6*count), 48, 6, 239 | chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
+				V_DrawFill(chatx+ boxw + 2, p_dispy- (6*count), 48, 6, CHATLUCENCY|cv_menubgcolor.value|chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
 				V_DrawSmallString(chatx+ boxw + 4, p_dispy- (6*count), chatsnap|V_ALLOWLOWERCASE, va("\x82%d\x80 - %s", i, name));
 				count++;
 			}
 		}
 		if (count == 0) // no results.
 		{
-			V_DrawFillConsoleMap(chatx+boxw+2, p_dispy- (6*count), 48, 6, 239 | chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
+			V_DrawFill(chatx+boxw+2, p_dispy- (6*count), 48, 6, CHATLUCENCY|cv_menubgcolor.value|chatsnap); // fill it like the chat so the text doesn't become hard to read because of the hud.
 			V_DrawSmallString(chatx+boxw+4, p_dispy- (6*count), chatsnap|V_ALLOWLOWERCASE, "NO RESULT.");
 		}
 	}

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -78,6 +78,10 @@ typedef struct
 // if it's over this amount, then you get a notice and DoSayCommand() will bail instead.
 #define DEDI_MAXMSGLEN 200
 
+// literally altered USERHUDTRANS.
+// I don't think it fits in v_video.h, though.
+#define CHATLUCENCY ((10-cv_chatlucency.value)<<V_ALPHASHIFT)
+
 // some functions
 void HU_AddChatText(const char *text, boolean playsound);
 

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -80,7 +80,7 @@ typedef struct
 
 // literally altered USERHUDTRANS.
 // I don't think it fits in v_video.h, though.
-#define CHATLUCENCY ((10-cv_chatlucency.value)<<V_ALPHASHIFT)
+#define CHATOPACITY ((10-cv_chatopacity.value)<<V_ALPHASHIFT)
 
 // some functions
 void HU_AddChatText(const char *text, boolean playsound);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1531,13 +1531,14 @@ static menuitem_t OP_BanpyuraOptionsMenu[] =
 	{IT_STRING | IT_CVAR,		NULL, "Show Char. Limit",         &cv_chat_showlimit,          62},
 	{IT_STRING | IT_CVAR,		NULL, "Clear Input text on Exit",&cv_chat_clearonexit,         67},
 	{IT_STRING | IT_CVAR,		NULL, "Chat Cursor",                  &cv_chatcursor,          72},
+	{IT_STRING | IT_CVAR,		 NULL, "Chat Opacity",			&cv_chatopacity,	77},
 
-	{IT_HEADER, 				NULL, "Network", 			            		NULL,		   82},
-	{IT_STRING | IT_CVAR,		NULL, "Minimum Delay",       		    &cv_mindelay,          88},
-	{IT_STRING | IT_CVAR,		NULL, "Gentlemen's Delay",       	  &cv_gentlemens,          93},
+	{IT_HEADER, 				NULL, "Network", 			            		NULL,		   87},
+	{IT_STRING | IT_CVAR,		NULL, "Minimum Delay",       		    &cv_mindelay,          93},
+	{IT_STRING | IT_CVAR,		NULL, "Gentlemen's Delay",       	  &cv_gentlemens,          98},
 
-	{IT_HEADER, 				NULL, "Rendering (OpenGL)", 			        NULL,		   103},
-	{IT_STRING|IT_CVAR,         NULL, "Light Dithering",     	   &cv_gllightdither,          109},
+	{IT_HEADER, 				NULL, "Rendering (OpenGL)", 			        NULL,		   108},
+	{IT_STRING|IT_CVAR,         NULL, "Light Dithering",     	   &cv_gllightdither,          114},
 };
 
 static menuitem_t OP_P1BanpyuraOptionsMenu[] =

--- a/src/netcode/d_netcmd.c
+++ b/src/netcode/d_netcmd.c
@@ -825,6 +825,7 @@ void D_RegisterClientCommands(void)
 	CV_RegisterVar(&cv_chat_showlimit);
 	CV_RegisterVar(&cv_chat_clearonexit);
 	CV_RegisterVar(&cv_chatcursor);
+	CV_RegisterVar(&cv_chatlucency);
 	CV_RegisterVar(&cv_crosshair);
 	CV_RegisterVar(&cv_crosshair2);
 	CV_RegisterVar(&cv_crosshair_invert);

--- a/src/netcode/d_netcmd.c
+++ b/src/netcode/d_netcmd.c
@@ -825,7 +825,7 @@ void D_RegisterClientCommands(void)
 	CV_RegisterVar(&cv_chat_showlimit);
 	CV_RegisterVar(&cv_chat_clearonexit);
 	CV_RegisterVar(&cv_chatcursor);
-	CV_RegisterVar(&cv_chatlucency);
+	CV_RegisterVar(&cv_chatopacity);
 	CV_RegisterVar(&cv_crosshair);
 	CV_RegisterVar(&cv_crosshair2);
 	CV_RegisterVar(&cv_crosshair_invert);


### PR DESCRIPTION
also now uses V_DrawFill instead of V_DrawFillConsoleMap and makes it use menubgcolor instead
This is basically a copy of translucenthud; though you'd probably want the translucency of it to *not* match your HUD.
Screenshots by merks (I was a bum)\:
<img width="800" height="600" alt="srb20621" src="https://github.com/user-attachments/assets/70f4b56f-e373-499f-b3d1-ded2d9047057" />
<img width="800" height="600" alt="srb20620" src="https://github.com/user-attachments/assets/682a0f97-9f37-4db3-a1bc-3ae6d039d533" />
<img width="800" height="600" alt="srb20619" src="https://github.com/user-attachments/assets/fb5e3827-3da5-4226-ab97-ea0f7394cfe9" />


also makes chatbacktint work on normal chat.
Maul me alive for anything

(Suggested by a friend of mine named ForestCore)