### PR TITLE
fix: No command input possible when no TTY is connected.

### DIFF
--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -802,7 +802,7 @@ static void I_StartupConsole(void)
 	if (framebuffer)
 		consolevent = false;
 
-	consolevent = consolevent || M_CheckParm("-forceconsole")
+	consolevent = consolevent || M_CheckParm("-forceconsole");
 
 	if (!consolevent) return;
 

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -801,12 +801,14 @@ static void I_StartupConsole(void)
 	if (framebuffer)
 		consolevent = false;
 
+	consolevent = consolevent || M_CheckParm("-forceconsole")
+
 	if (!consolevent) return;
 
 	if (isatty(STDIN_FILENO)!=1)
 	{
 		I_OutputMsg("stdin is not a tty, tty console mode failed\n");
-		consolevent = false;
+		consolevent = M_CheckParm("-forceconsole");
 		return;
 	}
 	memset(&tty_con, 0x00, sizeof(tty_con));

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -860,41 +860,36 @@ static void I_GetConsoleEvents(void)
 		if (read(STDIN_FILENO, &key, 1) == -1 || !key)
 			return;
 
-		// we have something
-		// backspace?
-		// NOTE TTimo testing a lot of values .. seems it's the only way to get it to work everywhere
-		if ((key == tty_erase) || (key == 127) || (key == 8))
-		{
-			if (tty_con.cursor > 0)
-			{
+		switch (key) {
+		default:
+			if (key == tty_erase); /* fallthrough */
+			else if (key < ' ') continue; // check if this is a control char
+			else if (tty_con.cursor < sizeof(tty_con.buffer)) {
+				// push regular character
+				ev.key = tty_con.buffer[tty_con.cursor] = key;
+				tty_con.cursor++;
+				/* Write the character for user feedback. */
+				write(STDOUT_FILENO, &key, 1);
+				break;
+			}
+			/* fallthrough */
+		case '\b':
+		case 127:
+			ev.key = KEY_BACKSPACE;
+			if (tty_con.cursor > 0) {
 				tty_con.cursor--;
 				tty_con.buffer[tty_con.cursor] = '\0';
 				tty_Back();
 			}
-			ev.key = KEY_BACKSPACE;
-		}
-		else if (key < ' ') // check if this is a control char
-		{
-			if (key == '\n')
-			{
-				tty_Clear();
-				tty_con.cursor = 0;
-				ev.key = KEY_ENTER;
-			}
-			else if (key == 0x4) // ^D, aka EOF
-			{
-				// shut down, most unix programs behave this way
-				I_Quit();
-			}
-			else continue;
-		}
-		else if (tty_con.cursor < sizeof(tty_con.buffer))
-		{
-			// push regular character
-			ev.key = tty_con.buffer[tty_con.cursor] = key;
-			tty_con.cursor++;
-			// print the current line (this is differential)
-			write(STDOUT_FILENO, &key, 1);
+			break;
+		case '\n':
+			ev.key = KEY_ENTER;
+			tty_Clear();
+			tty_con.cursor = 0;
+			break;
+		case 0x4: // ^D, aka EOF
+			// shut down, most unix programs behave this way
+			I_Quit();
 		}
 		if (ev.key) D_PostEvent(&ev);
 		//tty_FlushIn();

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -219,7 +219,8 @@ UINT8 graphics_started = 0;
 
 UINT8 keyboard_started = 0;
 
-static boolean consolevent = false;
+static boolean consolevent = false; /* Whether console events are processed. */
+static boolean consoleistty = true; /* Whether we're user or system facing. */
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
 static boolean framebuffer = false;
 #endif
@@ -808,7 +809,7 @@ static void I_StartupConsole(void)
 	if (isatty(STDIN_FILENO)!=1)
 	{
 		I_OutputMsg("stdin is not a tty, tty console mode failed\n");
-		consolevent = M_CheckParm("-forceconsole");
+		consoleistty = false;
 		return;
 	}
 	memset(&tty_con, 0x00, sizeof(tty_con));
@@ -869,14 +870,15 @@ static void I_GetConsoleEvents(void)
 				ev.key = tty_con.buffer[tty_con.cursor] = key;
 				tty_con.cursor++;
 				/* Write the character for user feedback. */
-				write(STDOUT_FILENO, &key, 1);
+				if (consoleistty)
+					write(STDOUT_FILENO, &key, 1);
 				break;
 			}
 			/* fallthrough */
 		case '\b':
 		case 127:
 			ev.key = KEY_BACKSPACE;
-			if (tty_con.cursor > 0) {
+			if (consoleistty && tty_con.cursor > 0) {
 				tty_con.cursor--;
 				tty_con.buffer[tty_con.cursor] = '\0';
 				tty_Back();
@@ -884,8 +886,10 @@ static void I_GetConsoleEvents(void)
 			break;
 		case '\n':
 			ev.key = KEY_ENTER;
-			tty_Clear();
-			tty_con.cursor = 0;
+			if (consoleistty) {
+				tty_Clear();
+				tty_con.cursor = 0;
+			}
 			break;
 		case 0x4: // ^D, aka EOF
 			// shut down, most unix programs behave this way
@@ -1119,7 +1123,7 @@ void I_OutputMsg(const char *fmt, ...)
 	}
 #else
 #ifdef HAVE_TERMIOS
-	if (consolevent && ttycon_ateol)
+	if (consoleistty && ttycon_ateol)
 	{
 		tty_Clear();
 		ttycon_ateol = false;
@@ -1129,7 +1133,7 @@ void I_OutputMsg(const char *fmt, ...)
 	if (!framebuffer)
 		fprintf(stderr, "%s", txt);
 #ifdef HAVE_TERMIOS
-	if (consolevent && txt[len-1] == '\n')
+	if (consoleistty && txt[len-1] == '\n')
 	{
 		write(STDOUT_FILENO, tty_con.buffer, tty_con.cursor);
 		ttycon_ateol = true;

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -580,12 +580,18 @@ static void I_StartupConsole(void)
 	if (framebuffer)
 		consolevent = SDL_FALSE;
 
+	if (M_CheckParm("-forceconsole"))
+		consolevent = SDL_TRUE;
+
 	if (!consolevent) return;
 
 	if (isatty(STDIN_FILENO)!=1)
 	{
 		I_OutputMsg("stdin is not a tty, tty console mode failed\n");
-		consolevent = SDL_FALSE;
+
+		if (!M_CheckParm("-forceconsole"))
+			consolevent = SDL_FALSE;
+
 		return;
 	}
 	memset(&tty_con, 0x00, sizeof(tty_con));


### PR DESCRIPTION
This is a port of patches made at the SRB2-edit project maintained by @luigi-budd:
* https://github.com/luigi-budd/SRB2-edit/pull/58
* https://github.com/luigi-budd/SRB2-edit/pull/61
* https://github.com/luigi-budd/SRB2-edit/pull/64

Whilst the patches are messy, it is the reality of the situation. I had to include some patches made by @romoney5, so if I were to "clean it up", it'd become murky who did what from a legality standpoint. I personally also think that this accurately reflects the history of these commits.
As mentioned, I mainly focussed on the patches needed to apply my set of patches, the binary has been tested on x86_64 Linux 7.1.8-arch1-3 with DEDICATED=1.
How I tested it is:

	[zieltjens@laptop-q bin]$ mkfifo stdin
	[zieltjens@laptop-q bin]$ tail -f stdin | ./srbd

Where in another terminal, or through backgrounding the process through ^Z and running ``bg``.

	[zieltjens@laptop-q bin]$ echo 'quit' >stdin

Without the patch series in place, the programme won't respond, with the patch series in place it will.

Within the commits authored by myself I explain in further detail what the issue is and how/why these patches solve the problem.

Finally, in terms of copyright it seems fine to me, since GPLv2 is compatible with GPLv2, though I am a programmer and not a lawyer. Considering @romoney5 has commits in this project as well, and we both know @Sterrenhart, I assume it is fine.