### PR TITLE
Add the total download bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Icon credits goes to ClovesCloestarSRB2 and his addon [New Springs](https://mb.s
 - Minimum input delay and Gentleman's delay (Ring Racers)
 - `cam_centertoggle` and `cam2_centertoggle` are not exclusive to the Automatic playstyle.
 - Rejoin server menu with timestamps (Ring Racers)
+- Total file download progress.
 
 ### Lua
 

--- a/src/netcode/client_connection.c
+++ b/src/netcode/client_connection.c
@@ -88,6 +88,8 @@ static boolean IsDownloadingFile(void)
 static void DrawConnectionStatusBox(void)
 {
 	M_DrawTextBox(BASEVIDWIDTH/2-128-8, BASEVIDHEIGHT-16-8, 32, 1);
+	if (cl_mode != CL_DOWNLOADSAVEGAME && filedownload.current != -1)
+		M_DrawTextBox(BASEVIDWIDTH/2-128-8, BASEVIDHEIGHT-46-8, 32, 1);
 
 	if (cl_mode == CL_CONFIRMCONNECT || IsDownloadingFile())
 		return;
@@ -115,7 +117,7 @@ static void DrawFileProgress(fileneeded_t *file, int y)
 
 	V_DrawString(BASEVIDWIDTH/2-128, y, V_20TRANS|V_ALLOWLOWERCASE|MENUCAPS, progress_str);
 
-	V_DrawRightAlignedString(BASEVIDWIDTH/2+128, y, V_20TRANS|V_MONOSPACE|MENUCAPS, va("%3.1fK/s ", ((double)getbps)/1024));
+	V_DrawRightAlignedString(BASEVIDWIDTH/2+128, y, V_20TRANS|V_MONOSPACE|MENUCAPS, va("%3.1fKB/s", ((double)getbps)/1024));
 }
 
 static void CL_DrawAddonTypes(void)
@@ -528,6 +530,33 @@ static void CL_DrawDownloadAddonList(void)
 #undef charsonside
 }
 
+static void DrawOverallProgress(int y)
+{
+	UINT32 totalsize = filedownload.totalsize;
+	INT32 downloadedfiles = filedownload.completednum;
+	INT32 totalfiles = filedownload.remaining + filedownload.completednum;
+	INT32 downloaded = filedownload.completedsize;
+	if (fileneeded[filedownload.current].currentsize != fileneeded[filedownload.current].totalsize)
+		downloaded = filedownload.completedsize + fileneeded[filedownload.current].currentsize;
+
+	INT32 dldlength = (INT32)((downloaded/(double)totalsize) * 256);
+	if (dldlength > 256)
+		dldlength = 256;
+	V_DrawFill(BASEVIDWIDTH/2-128, y, 256, 8, 111);
+	V_DrawFill(BASEVIDWIDTH/2-128, y, dldlength, 8, 96);
+
+	const char *progress_str;
+	if (totalsize >= 1024*1024)
+		progress_str = va(" %.2fMiB/%.2fMiB", (double)downloaded / (1024*1024), (double)totalsize / (1024*1024));
+	else if (totalsize < 1024)
+		progress_str = va(" %4uB/%4uB", downloaded, totalsize);
+	else
+		progress_str = va(" %.2fKiB/%.2fKiB", (double)downloaded / 1024, (double)totalsize / 1024);
+
+	V_DrawString(BASEVIDWIDTH/2-128, y, V_20TRANS|V_ALLOWLOWERCASE, progress_str);
+	V_DrawRightAlignedString(BASEVIDWIDTH/2+128, y, V_20TRANS|V_ALLOWLOWERCASE|MENUCAPS, va("%2u/%2u Files", downloadedfiles+1, totalfiles));
+}
+
 //
 // CL_DrawConnectionStatus
 //
@@ -744,7 +773,7 @@ static void CL_DrawConnectionStatus(void)
 			const char *download_str = M_GetText("Downloading \"%s\"");
 #endif
 
-			V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-16-24, V_ALLOWLOWERCASE|MENUCOLOR|MENUCAPS,
+			V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-46-24, MENUCOLOR|MENUCAPS,
 				va(download_str, tempname));
 
 			// Rusty: actually lets do this instead
@@ -764,16 +793,18 @@ static void CL_DrawConnectionStatus(void)
 					strlcpy(tempname, http_source, sizeof(tempname));
 				}
 
-				V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-16-16, V_ALLOWLOWERCASE|MENUCOLOR|MENUCAPS,
+				V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-46-16, V_ALLOWLOWERCASE|MENUCOLOR|MENUCAPS,
 					va(M_GetText("from %s"), tempname));
 			}
 			else
 			{
-				V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-16-16, V_ALLOWLOWERCASE|MENUCOLOR|MENUCAPS,
+				V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-46-16, V_ALLOWLOWERCASE|MENUCOLOR|MENUCAPS,
 					M_GetText("from the server"));
 			}
+			DrawFileProgress(file, BASEVIDHEIGHT-46);
 
-			DrawFileProgress(file, BASEVIDHEIGHT-16);
+			V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-16-14, V_ALLOWLOWERCASE|MENUCOLOR|MENUCAPS, "Total Progress");
+			DrawOverallProgress(BASEVIDHEIGHT-16);
 		}
 		else
 		{
@@ -1186,6 +1217,7 @@ static void ShowDownloadConsentMessage(void)
 		if (IsFileDownloadable(&fileneeded[i]))
 			totalsize += fileneeded[i].totalsize;
 	}
+	filedownload.totalsize = totalsize;
 
 	/*
 	const char *downloadsize = GetPrintableFileSize(totalsize);

--- a/src/netcode/d_netfil.h
+++ b/src/netcode/d_netfil.h
@@ -106,6 +106,7 @@ typedef struct
 	INT32 remaining;
 	INT32 completednum;
 	UINT32 completedsize;
+	UINT64 totalsize;
 
 	boolean http_failed;
 	boolean http_running;

--- a/src/snake.c
+++ b/src/snake.c
@@ -23,7 +23,7 @@
 #define SPEED 5
 
 #define NUM_BLOCKS_X 20
-#define NUM_BLOCKS_Y 10
+#define NUM_BLOCKS_Y 8
 #define BLOCK_SIZE 12
 #define BORDER_SIZE 12
 
@@ -32,7 +32,7 @@
 
 #define LEFT_X ((BASEVIDWIDTH - MAP_WIDTH) / 2 - BORDER_SIZE)
 #define RIGHT_X (LEFT_X + MAP_WIDTH + BORDER_SIZE * 2 - 1)
-#define BOTTOM_Y (BASEVIDHEIGHT - 48)
+#define BOTTOM_Y (BASEVIDHEIGHT - 76)
 #define TOP_Y (BOTTOM_Y - MAP_HEIGHT - BORDER_SIZE * 2 + 1)
 
 enum bonustype_s {


### PR DESCRIPTION
This adds the total download bar that is present in SRB2 2.2.16, several SRB2 forks and several SRB2Kart forks (and probably many other forks).

<img width="1368" height="795" alt="imagen" src="https://github.com/user-attachments/assets/3fef27d3-e7ea-4692-be44-12b794205202" />
