### PR TITLE
Fix memory leak in lua globals

### DIFF
--- a/src/lua_script.c
+++ b/src/lua_script.c
@@ -547,10 +547,11 @@ static int setglobals(lua_State *L)
 		return 0;
 	}
 
+	Z_Free(name);
+
 	if (LUA_CheckGlobals(L, csname))
 		return 0;
 
-	Z_Free(name);
 	return luaL_error(L, "Implicit global " LUA_QS " prevented. Create a local variable instead.", csname);
 }
 


### PR DESCRIPTION
see [MR !2818](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2818)

if check right above Z_Free leads to an early bail without freeing name, which z_strdup had z_malloc'd