### PR TITLE
tiny centerview cleanup && `GC_LOOK` parity

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1406,25 +1406,23 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics, UINT8 ssplayer)
 		return;
 	}
 
-	// Centerview can be a toggle in simple mode!
+	static boolean last_centerviewdown[2], centerviewhold[2]; // detect taps for toggle behavior
+	boolean down = PLAYERINPUTDOWN(ssplayer, GC_CENTERVIEW);
+
+	// why was this ever restricted to simple/automatic ???
+	// - nikoberry
+	if (cv_cam_centertoggle[forplayer].value == 0)
+		centerviewdown = down;
+	else
 	{
-		static boolean last_centerviewdown[2], centerviewhold[2]; // detect taps for toggle behavior
-		boolean down = PLAYERINPUTDOWN(ssplayer, GC_CENTERVIEW);
+		if (down && !last_centerviewdown[forplayer])
+			centerviewhold[forplayer] = !centerviewhold[forplayer];
+		last_centerviewdown[forplayer] = down;
 
-		if (cv_cam_centertoggle[forplayer].value == 0) {
-				centerviewdown = down;
-			}
-		else
-		{
-			if (down && !last_centerviewdown[forplayer])
-				centerviewhold[forplayer] = !centerviewhold[forplayer];
-			last_centerviewdown[forplayer] = down;
+		if (cv_cam_centertoggle[forplayer].value == 2 && !down && !ticcmd_ztargetfocus[forplayer])
+			centerviewhold[forplayer] = false;
 
-			if (cv_cam_centertoggle[forplayer].value == 2 && !down && !ticcmd_ztargetfocus[forplayer])
-				centerviewhold[forplayer] = false;
-
-			centerviewdown = centerviewhold[forplayer];
-		}
+		centerviewdown = centerviewhold[forplayer];
 	}
 
 	if (centerviewdown)
@@ -1529,31 +1527,32 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics, UINT8 ssplayer)
 		cmd->buttons |= BT_JUMP;
 
 	// player aiming shit, ahhhh...
+	INT32 player_invert = invertmouse ? -1 : 1;
+	INT32 screen_invert =
+		(player->mo && (player->mo->eflags & MFE_VERTICALFLIP)
+		 && (!thiscam->chase || player->pflags & PF_FLIPCAM)) //because chasecam's not inverted
+		 ? -1 : 1; // set to -1 or 1 to multiply
+	INT32 configlookaxis = ssplayer == 1 ? cv_lookaxis.value : cv_lookaxis2.value;
+
+	// mouse look stuff (mouse look is not the same as mouse aim)
+	if (mouseaiming)
 	{
-		INT32 player_invert = invertmouse ? -1 : 1;
-		INT32 screen_invert =
-			(player->mo && (player->mo->eflags & MFE_VERTICALFLIP)
-			 && (!thiscam->chase || player->pflags & PF_FLIPCAM)) //because chasecam's not inverted
-			 ? -1 : 1; // set to -1 or 1 to multiply
-		 INT32 configlookaxis = ssplayer == 1 ? cv_lookaxis.value : cv_lookaxis2.value;
+		keyboard_look[forplayer] = false;
 
-		// mouse look stuff (mouse look is not the same as mouse aim)
-		if (mouseaiming)
-		{
-			keyboard_look[forplayer] = false;
+		// looking up/down
+		*myaiming += (mldy<<19)*player_invert*screen_invert;
+	}
 
-			// looking up/down
-			*myaiming += (mldy<<19)*player_invert*screen_invert;
-		}
+	if (analogjoystickmove && joyaiming[forplayer] && lookjoystickvector.yaxis != 0 && configlookaxis != 0)
+		*myaiming += (FixedMul(lookjoystickvector.yaxis, gamepadysensitivity)<<16) * screen_invert;
 
-		if (analogjoystickmove && joyaiming[forplayer] && lookjoystickvector.yaxis != 0 && configlookaxis != 0)
-			*myaiming += (FixedMul(lookjoystickvector.yaxis, gamepadysensitivity)<<16) * screen_invert;
+	// spring back if not using keyboard neither mouselookin'
+	if (!keyboard_look[forplayer] && configlookaxis == 0 && !joyaiming[forplayer] && !mouseaiming)
+		*myaiming = 0;
 
-		// spring back if not using keyboard neither mouselookin'
-		if (!keyboard_look[forplayer] && configlookaxis == 0 && !joyaiming[forplayer] && !mouseaiming)
-			*myaiming = 0;
-
-		if (!(player->powers[pw_carry] == CR_NIGHTSMODE))
+	if (!(player->powers[pw_carry] == CR_NIGHTSMODE))
+	{
+		if (!ticcmd_centerviewdown[forplayer]) // for parity with mlook
 		{
 			if (PLAYERINPUTDOWN(ssplayer, GC_LOOKUP) || (gamepadjoystickmove && lookjoystickvector.yaxis < 0))
 			{
@@ -1565,9 +1564,8 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics, UINT8 ssplayer)
 				*myaiming -= KB_LOOKSPEED * screen_invert;
 				keyboard_look[forplayer] = true;
 			}
-			else if (ticcmd_centerviewdown[forplayer])
-				*myaiming = 0;
-		}
+		} else
+			*myaiming = 0;
 
 		// accept no mlook for network games
 		if (!cv_allowmlook.value)


### PR DESCRIPTION
same as upstream mr [!2819](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2819), being thrown here since it resolves gc_lookup/down still affecting aiming and then snapping back, which is probably nice to also have in 2.2.15 and not just next

this just essentially a tiny touchup of feea9b5e784c3ec21e96384943a65b25736cd86b (killing some braces, re-indenting, and moving an ifcheck)