### PR TITLE
Fix Download Addon List

### DIFF
--- a/src/netcode/client_connection.c
+++ b/src/netcode/client_connection.c
@@ -403,37 +403,40 @@ static void CL_DrawDownloadAddonList(void)
 
 #define charsonside 18
 #define maxcharlen (charsonside * 2) + 3 // 3 for the 3 dots
+	INT32 i;
 	INT32 count = 0;
 	INT32 x = 14;
 	INT32 y = ypos + 68;
 	INT32 height = 10;
 	INT32 totalsize = 0;
-	INT32 addons = 0;
-
-	if (fileneedednum > 0)
+	fileneeded_t filelist[fileneedednum];
+	INT32 filelistsize = 0;
+	for (int j = 0; j < fileneedednum; j++)
 	{
-		for (INT32 i = viewfiles; i < fileneedednum; i++)
+		if ((fileneeded[j].status != FS_NOTFOUND) && (fileneeded[j].status != FS_MD5SUMBAD))
+			continue;
+
+		filelist[filelistsize] = fileneeded[j];
+		filelistsize++;
+		totalsize += fileneeded[j].totalsize;
+	}
+	totalsize = (float)totalsize;
+
+	if (filelistsize > 0)
+	{
+		for (i = viewfiles; i < filelistsize; i++)
 		{
-			if ((fileneeded[i].status != FS_NOTFOUND) && (fileneeded[i].status != FS_MD5SUMBAD))
-				continue;
-
-			addons++;
-			totalsize += fileneeded[i].totalsize;
-
-			if (count == MAXLISTADDONS || count == MAXLISTADDONS * 2)
-				continue; // continue here so that addons/totalsize are updated but nothing else is drawn
-
-			if (addons & 1)
+			if (i & 1)
 				V_DrawFill(x - 2, y - 1, 290, height, (cv_menubgcolor.value - 3));
 			else
 				V_DrawFill(x - 2, y - 1, 290, height, (cv_menubgcolor.value - 2));
 			
 			INT32 color = 0; // new addon
-			if (fileneeded[i].status == FS_MD5SUMBAD)
+			if (filelist[i].status == FS_MD5SUMBAD)
 				color = V_SKYMAP; // addon update
 
 			char tempname[28];
-			char *filename = fileneeded[i].filename;
+			char *filename = filelist[i].filename;
 			filename += strlen(filename) - nameonlylength(filename);
 			if (strlen(filename) > (sizeof(tempname) - 1)) // too long to display fully
 			{
@@ -451,7 +454,7 @@ static void CL_DrawDownloadAddonList(void)
 
 			V_DrawThinString(x + 6 * 3, y + 1, V_ALLOWLOWERCASE|V_6WIDTHSPACE|color, filename);
 
-			float file_size = ((float)fileneeded[i].totalsize);
+			float file_size = ((float)filelist[i].totalsize);
 			const char *size_mode = "B";
 			if (file_size >= (1024.0f * 1024.0f))
 			{
@@ -467,9 +470,11 @@ static void CL_DrawDownloadAddonList(void)
 
 			y += height;
 			count++;
+			if (count == MAXLISTADDONS)
+				break;
+			if (count == MAXLISTADDONS * 2)
+				break;
 		}
-
-		totalsize = (float)totalsize;
 
 		const char *size_mode = "B";
 		if (totalsize >= (1024.0f * 1024.0f))
@@ -484,15 +489,15 @@ static void CL_DrawDownloadAddonList(void)
 		}
 
 		V_DrawString(12, ypos + 58, V_ALLOWLOWERCASE|MENUCOLOR,
-			va("Download %i addons?", addons));
+			va("Download %i addons?", filelistsize));
 		V_DrawRightAlignedString(BASEVIDWIDTH - x - 3, ypos + 58, V_ALLOWLOWERCASE|MENUCOLOR, va("%.1f%s total", (float)totalsize, size_mode));
 
-		if (addons >= MAXLISTADDONS)
+		if (filelistsize >= MAXLISTADDONS)
 		{
 			if (viewfiles)
 				V_DrawRightAlignedThinString(BASEVIDWIDTH - 10, (ypos + 58 + 10) - ((ccstime % 8) / 5), MENUCOLOR, "\x1A");
 
-			if (viewfiles != (addons - ADDONSCROLLLIMIT))
+			if (viewfiles != (filelistsize - ADDONSCROLLLIMIT))
 				V_DrawRightAlignedThinString(BASEVIDWIDTH - 10, (y - 10) + ((ccstime % 8) / 5), MENUCOLOR, "\x1B");
 		}
 	}
@@ -514,7 +519,7 @@ static void CL_DrawDownloadAddonList(void)
 		V_ALLOWLOWERCASE, va("%sESC%s - Cancel", GetChatColorFromVideoFlag(MENUCOLOR), "\x80")
 	);
 
-	if (addons >= MAXLISTADDONS)
+	if (filelistsize >= MAXLISTADDONS)
 	{
 		V_DrawCenteredThinString(
 			BASEVIDWIDTH/2, BASEVIDHEIGHT - (ypos + 15),
@@ -1170,7 +1175,7 @@ static void BeginDownload(boolean direct)
 	}
 }
 
-static void M_ConfirmConnect(event_t *ev)
+/*static void M_ConfirmConnect(event_t *ev)
 {
 	if (ev->type == ev_keydown)
 	{
@@ -1185,7 +1190,7 @@ static void M_ConfirmConnect(event_t *ev)
 			M_ClearMenus(true);
 		}
 	}
-}
+}*/
 
 static const char *GetPrintableFileSize(UINT64 filesize)
 {
@@ -1334,13 +1339,13 @@ static boolean CL_FinishedFileList(void)
 	{
 		if (serverisfull)
 		{
-			M_StartMessage(M_GetText(
+			/*M_StartMessage(M_GetText(
 				"This server is full!\n"
 				"\n"
 				"You may load server addons (if any), and wait for a slot.\n"
 				"\n"
 				"Press ENTER to continue\nor ESC to cancel.\n\n"
-			), M_ConfirmConnect, MM_EVENTHANDLER);
+			), M_ConfirmConnect, MM_EVENTHANDLER);*/
 			cl_mode = CL_CONFIRMCONNECT;
 			curfadevalue = 0;
 		}


### PR DESCRIPTION
This fixes a regression with the download addon list when about to download the server's addons.
Plus fixes an instance of the server is full dialog appearing when it should just use the same screen from download addon list instead.